### PR TITLE
Blog: tag filters, date timeline, thumbnail cards

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,7 +12,7 @@ layout: default
       <span class="reading-time">{{ minutes }} min read</span>
       {%- if page.tags and page.tags.size > 0 %}
       <span class="post-tags">
-        {%- for tag in page.tags %}<span class="tag">{{ tag }}</span>{% endfor -%}
+        {%- for tag in page.tags %}<a class="tag" href="{{ '/blog/' | relative_url }}?tag={{ tag | url_encode }}">{{ tag }}</a>{% endfor -%}
       </span>
       {%- endif %}
     </div>

--- a/_posts/2026-06-24-serverless-event-ingestion-pipeline.md
+++ b/_posts/2026-06-24-serverless-event-ingestion-pipeline.md
@@ -4,6 +4,7 @@ title: "Designing a Serverless Event Ingestion & Ranking Pipeline"
 date: 2026-06-24
 tags: [System Design, Serverless, AWS]
 description: "A walkthrough of an event-driven, fully serverless pipeline that crawls, enriches, ranks, and publishes social events on AWS — and the design trade-offs behind it."
+image: /images/events-planner-ingest-system-design.png
 ---
 
 Discovering interesting events shouldn't require ten open tabs. This post walks

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -2,24 +2,99 @@
    blog.css — blog index, post layout, Notion-style callouts, mermaid, code
    ========================================================================= */
 
-/* ---------- Blog index list ---------- */
-.blog-intro { color: var(--ink-faint); font-size: 1.02rem; max-width: 640px; margin: .2rem 0 2rem; }
+/* ---------- Blog index ---------- */
+.blog-intro { color: var(--ink-faint); font-size: 1.02rem; max-width: 640px; margin: .2rem 0 1.4rem; }
 
+/* Controls: tag filter chips + year jump (sticky) */
+.blog-controls {
+  position: sticky; top: 0; z-index: 20; background: var(--bg);
+  padding: .7rem 0 .75rem; margin-bottom: .4rem; border-bottom: 1px solid var(--line);
+  display: flex; flex-wrap: wrap; gap: .7rem 1rem; align-items: center; justify-content: space-between;
+}
+.filter-row { display: flex; flex-wrap: wrap; gap: .45rem; }
+.chip-filter {
+  font-family: inherit; cursor: pointer; font-size: .82rem; font-weight: 600; color: var(--ink-soft);
+  background: #fff; border: 1px solid var(--line); padding: .32rem .75rem; border-radius: 999px;
+  display: inline-flex; align-items: center; gap: .35rem; transition: all .15s ease; line-height: 1.2;
+}
+.chip-filter:hover { border-color: var(--accent); color: var(--accent); }
+.chip-filter .count { font-size: .7rem; font-weight: 700; color: var(--ink-faint); background: var(--bg); border-radius: 999px; padding: 0 .4rem; }
+.chip-filter.is-active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.chip-filter.is-active .count { color: #fff; background: rgba(255,255,255,.22); }
+
+.year-jump { display: flex; gap: .35rem; }
+.year-jump .yr-chip {
+  font-size: .8rem; font-weight: 700; color: var(--ink-faint); text-decoration: none;
+  padding: .3rem .6rem; border-radius: 999px; border: 1px solid var(--line); background: #fff;
+}
+.year-jump .yr-chip:hover { color: var(--accent); border-color: var(--accent); text-decoration: none; }
+
+/* Year divider (sticky timeline marker) */
+.year-divider {
+  position: sticky; top: 54px; z-index: 10; margin: 1.2rem 0 .9rem;
+  display: flex; align-items: center; gap: .8rem; pointer-events: none;
+}
+.year-divider span {
+  font-size: .78rem; font-weight: 800; letter-spacing: .08em; color: var(--ink-faint);
+  background: var(--bg); padding: .15rem .55rem .15rem 0;
+}
+.year-divider::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+
+/* Feed + cards */
 .post-feed { list-style: none; margin: 0; padding: 0; }
 .post-card {
-  display: block; background: var(--card); border: 1px solid var(--line);
-  border-radius: var(--radius); padding: 1.4rem 1.5rem; margin-bottom: 1.1rem;
-  box-shadow: var(--shadow); transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+  position: relative; display: grid; grid-template-columns: 132px minmax(0,1fr); gap: 1.2rem;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 1.1rem 1.3rem; margin-bottom: 1rem; box-shadow: var(--shadow);
+  transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
 }
-.post-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-lg); border-color: #d4dbe6; text-decoration: none; }
-.post-card .meta { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; font-size: .8rem; color: var(--ink-faint); margin-bottom: .5rem; }
-.post-card .meta time { font-weight: 600; }
-.post-card h3 { margin: 0 0 .4rem; font-size: 1.28rem; color: var(--ink); }
-.post-card p { margin: 0; color: var(--ink-soft); font-size: .95rem; }
-.post-card .read { display: inline-block; margin-top: .7rem; color: var(--accent); font-weight: 600; font-size: .88rem; }
+.post-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-lg); border-color: #d4dbe6; }
 
+.pc-thumb {
+  display: block; align-self: stretch; min-height: 96px; border-radius: var(--radius-sm); overflow: hidden;
+  border: 1px solid var(--line); background: #f0f2f6;
+}
+.pc-thumb img { width: 100%; height: 100%; object-fit: cover; object-position: top center; margin: 0; border: 0; border-radius: 0; display: block; }
+.pc-thumb.placeholder { display: flex; align-items: center; justify-content: center; text-align: center; padding: .6rem; border: 0; }
+.pc-thumb.placeholder span { color: #fff; font-weight: 700; font-size: .82rem; line-height: 1.25; text-shadow: 0 1px 2px rgba(0,0,0,.22); }
+.pc-thumb.placeholder.g0 { background: linear-gradient(135deg,#1e3a8a,#2563eb); }
+.pc-thumb.placeholder.g1 { background: linear-gradient(135deg,#4f46e5,#7c3aed); }
+.pc-thumb.placeholder.g2 { background: linear-gradient(135deg,#0f766e,#14b8a6); }
+.pc-thumb.placeholder.g3 { background: linear-gradient(135deg,#b45309,#f59e0b); }
+.pc-thumb.placeholder.g4 { background: linear-gradient(135deg,#9d174d,#db2777); }
+.pc-thumb.placeholder.g5 { background: linear-gradient(135deg,#374151,#6b7280); }
+
+.pc-body { display: flex; flex-direction: column; min-width: 0; }
+.pc-body .meta { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; font-size: .8rem; color: var(--ink-faint); margin-bottom: .35rem; }
+.pc-body .meta time { font-weight: 600; }
+.pc-body .meta .dot { color: var(--line); }
+.post-card h3 { margin: 0 0 .35rem; font-size: 1.24rem; line-height: 1.3; }
+.pc-title-link { color: var(--ink); text-decoration: none; }
+.pc-title-link:hover { color: var(--accent); text-decoration: none; }
+.pc-title-link::after { content: ""; position: absolute; inset: 0; z-index: 1; }  /* stretched: whole card clickable */
+.post-card p { margin: 0; color: var(--ink-soft); font-size: .94rem; line-height: 1.55; }
+
+.pc-tags { position: relative; z-index: 2; display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .7rem; }
+
+/* Tag chips — shared by index cards and single-post header (clickable filters) */
+.pc-tags .tag, .post-tags .tag {
+  font-size: .73rem; font-weight: 600; color: var(--ink-soft); text-decoration: none; cursor: pointer;
+  background: var(--accent-soft); border: 1px solid #dbe4ff; padding: .14rem .55rem; border-radius: 999px;
+  transition: all .12s ease;
+}
+.pc-tags .tag:hover, .post-tags .tag:hover { color: #fff; background: var(--accent); border-color: var(--accent); text-decoration: none; }
 .post-tags { display: inline-flex; flex-wrap: wrap; gap: .35rem; }
-.post-tags .tag { font-size: .72rem; }
+
+.no-results { color: var(--ink-faint); padding: 1.5rem 0; }
+.link-btn { font-family: inherit; background: none; border: 0; color: var(--accent); font-weight: 600; cursor: pointer; padding: 0; }
+.link-btn:hover { text-decoration: underline; }
+
+@media (max-width: 560px) {
+  .post-card { grid-template-columns: 1fr; }
+  .pc-thumb { aspect-ratio: 16/9; min-height: 0; }
+  .blog-controls { position: static; }
+  .year-divider { top: 0; }
+}
 
 /* ---------- Single post ---------- */
 .post { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -148,11 +148,74 @@
     document.querySelectorAll(".portfolio-feed .portfolio-item").forEach(function (s) { io.observe(s); });
   }
 
+  /* ---------------------------------------------------------------------
+     5) Blog tag filtering: filter the post feed by topic in place, sync
+        the chosen tag to the URL (?tag=), and hide empty year dividers.
+     --------------------------------------------------------------------- */
+  function setupBlogFilter() {
+    var root = document.querySelector("[data-blog-filter]");
+    var feed = document.querySelector("[data-blog-feed]");
+    if (!root || !feed) return;
+
+    var chips = Array.prototype.slice.call(root.querySelectorAll(".chip-filter"));
+    var cards = Array.prototype.slice.call(feed.querySelectorAll(".post-card"));
+    var dividers = Array.prototype.slice.call(feed.querySelectorAll(".year-divider"));
+    var inCardTags = Array.prototype.slice.call(feed.querySelectorAll(".pc-tags .tag"));
+    var noRes = document.querySelector(".no-results");
+    var clearBtn = document.querySelector("[data-filter-clear]");
+
+    function apply(filter, scroll) {
+      filter = filter || "*";
+      var anyVisible = false;
+      cards.forEach(function (c) {
+        var tags = (c.getAttribute("data-tags") || "").split("|");
+        var show = filter === "*" || tags.indexOf(filter) > -1;
+        c.style.display = show ? "" : "none";
+        if (show) anyVisible = true;
+      });
+      // hide a year divider when none of the cards under it are visible
+      dividers.forEach(function (d) {
+        var n = d.nextElementSibling, has = false;
+        while (n && !n.classList.contains("year-divider")) {
+          if (n.classList.contains("post-card") && n.style.display !== "none") { has = true; break; }
+          n = n.nextElementSibling;
+        }
+        d.style.display = has ? "" : "none";
+      });
+      chips.forEach(function (ch) {
+        ch.classList.toggle("is-active", (ch.getAttribute("data-filter") || "*") === filter);
+      });
+      if (noRes) noRes.hidden = anyVisible;
+
+      var url = new URL(window.location);
+      if (filter === "*") url.searchParams.delete("tag"); else url.searchParams.set("tag", filter);
+      history.replaceState(null, "", url);
+
+      if (scroll && root.scrollIntoView) root.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    chips.forEach(function (ch) {
+      ch.addEventListener("click", function () { apply(ch.getAttribute("data-filter")); });
+    });
+    inCardTags.forEach(function (a) {
+      a.addEventListener("click", function (e) { e.preventDefault(); apply(a.getAttribute("data-tag"), true); });
+    });
+    if (clearBtn) clearBtn.addEventListener("click", function () { apply("*"); });
+
+    // initial filter from ?tag= (e.g. arriving from a single post's tag link)
+    var initial = new URL(window.location).searchParams.get("tag");
+    if (initial) {
+      var match = chips.some(function (ch) { return ch.getAttribute("data-filter") === initial; });
+      if (match) apply(initial);
+    }
+  }
+
   function init() {
     setupCallouts();   // before reveal, so callouts can also animate
     setupInfinite();
     setupReveal();
     setupScrollspy();
+    setupBlogFilter();
   }
 
   if (document.readyState === "loading") {

--- a/blog.md
+++ b/blog.md
@@ -10,24 +10,56 @@ description: "System design write-ups, platform & AI engineering notes, and deep
 <p class="blog-intro">System design write-ups, platform &amp; AI engineering notes, and deep dives. Diagrams and code throughout.</p>
 
 {%- if site.posts.size > 0 %}
-<div class="post-feed" data-infinite data-initial="8" data-batch="6">
-  {%- for post in site.posts %}
-  {%- assign words = post.content | number_of_words -%}
-  {%- assign minutes = words | divided_by: 200 | plus: 1 -%}
-  <a class="post-card" href="{{ post.url | relative_url }}">
-    <div class="meta">
-      <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
-      <span>· {{ minutes }} min read</span>
-      {%- if post.tags and post.tags.size > 0 %}
-      <span class="post-tags">{% for tag in post.tags %}<span class="tag">{{ tag }}</span>{% endfor %}</span>
+{%- assign by_year = site.posts | group_by_exp: "p", "p.date | date: '%Y'" %}
+
+<div class="blog-controls" data-blog-filter>
+  <div class="filter-row" role="group" aria-label="Filter posts by topic">
+    <button class="chip chip-filter is-active" data-filter="*" type="button">All <span class="count">{{ site.posts.size }}</span></button>
+    {%- assign tags = site.tags | sort %}
+    {%- for t in tags %}
+    <button class="chip chip-filter" data-filter="{{ t[0] | escape }}" type="button">{{ t[0] }} <span class="count">{{ t[1].size }}</span></button>
+    {%- endfor %}
+  </div>
+  {%- if by_year.size > 1 %}
+  <div class="year-jump" aria-label="Jump to year">
+    {%- for yg in by_year %}<a class="yr-chip" href="#y-{{ yg.name }}">{{ yg.name }}</a>{% endfor %}
+  </div>
+  {%- endif %}
+</div>
+
+<div class="post-feed" data-blog-feed>
+  {%- for yg in by_year %}
+  <div class="year-divider" id="y-{{ yg.name }}"><span>{{ yg.name }}</span></div>
+  {%- for post in yg.items %}
+  {%- assign words = post.content | number_of_words %}
+  {%- assign minutes = words | divided_by: 200 | plus: 1 %}
+  {%- assign seed = post.title | size | modulo: 6 %}
+  {%- assign primary = post.tags | first | default: "Post" %}
+  <article class="post-card" data-tags="{{ post.tags | join: '|' | escape }}">
+    {%- if post.image %}
+    <a class="pc-thumb" href="{{ post.url | relative_url }}" tabindex="-1" aria-hidden="true"><img src="{{ post.image | relative_url }}" alt="" loading="lazy"></a>
+    {%- else %}
+    <a class="pc-thumb placeholder g{{ seed }}" href="{{ post.url | relative_url }}" tabindex="-1" aria-hidden="true"><span>{{ primary }}</span></a>
+    {%- endif %}
+    <div class="pc-body">
+      <div class="meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
+        <span class="dot">·</span><span>{{ minutes }} min read</span>
+      </div>
+      <h3><a class="pc-title-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a></h3>
+      <p>{{ post.excerpt | strip_html | truncatewords: 28 }}</p>
+      {%- if post.tags.size > 0 %}
+      <div class="pc-tags">
+        {%- for tag in post.tags %}<a class="tag" href="{{ '/blog/' | relative_url }}?tag={{ tag | url_encode }}" data-tag="{{ tag | escape }}">{{ tag }}</a>{% endfor %}
+      </div>
       {%- endif %}
     </div>
-    <h3>{{ post.title | escape }}</h3>
-    <p>{{ post.excerpt | strip_html | truncatewords: 32 }}</p>
-    <span class="read">Read more →</span>
-  </a>
+  </article>
+  {%- endfor %}
   {%- endfor %}
 </div>
+
+<p class="no-results" hidden>No posts match that topic. <button class="link-btn" data-filter-clear type="button">Clear filter</button></p>
 {%- else %}
 <p>No posts yet — first write-ups landing soon.</p>
 {%- endif %}


### PR DESCRIPTION
Implements the requested blog upgrades (from the screenshots).

## Tags → selectable filters
- A sticky **filter bar** of topic chips (with post counts); click to filter the feed in place, "All" resets. Selection syncs to `?tag=` in the URL.
- **In-card tag chips** filter live; **single-post header tags** now link into the filtered blog (`/blog/?tag=...`). Tags restyled into proper chips.

## Date navigation (the recommended approach)
- Posts grouped by **year** with a **sticky year divider** that pins as you scroll — the timeline pattern, which scales as the blog grows.
- **Year quick-jump** chips appear automatically once there's more than one year.

## Thumbnail cards
- Each card now has a **miniature image**: the post's `image:` if set, otherwise a clean **gradient tile labeled with its primary topic**.
- Whole card is click-through (stretched title link) while tag chips stay independently clickable.
- The serverless post now uses its architecture diagram as the thumbnail.

> [!NOTE]
> This touches `_layouts/post.html` (post-header tag links), so the PR gatekeeper will route it to **owner-merge** rather than auto-merging. The rest is `blog.md` + CSS/JS + one post's front matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKNA2dmcvSTdUb658quM4n