### PR TITLE
fix: card thumbnails zoom/center-crop (cover) like portfolio

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -81,11 +81,11 @@
 
 .pc-thumb {
   position: relative; z-index: 2;        /* sit above the card's stretched title link so the image opens full */
-  align-self: stretch; min-height: 100%; overflow: hidden; background: #f6f7f9;
+  align-self: stretch; min-height: 100%; overflow: hidden; background: #f0f2f6;
   border-left: 1px solid var(--line);
 }
 .pc-thumb img {
-  width: 100%; height: 100%; object-fit: contain; object-position: center; padding: 10px; box-sizing: border-box;
+  width: 100%; height: 100%; object-fit: cover; object-position: center;
   margin: 0; border: 0; border-radius: 0; display: block; transition: transform .4s ease;
 }
 .post-card:hover .pc-thumb img { transform: scale(1.05); }


### PR DESCRIPTION
Card diagram thumbnails were `object-fit:contain` (whole diagram, tiny + letterboxed). Switch to `object-fit:cover` + `object-position:center` — fill the panel, zoomed, cropping edges from the center, matching the portfolio. Full diagram is still one click away (opens the SVG in a new tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)