### PR TITLE
blog cards: noreferrer + new-tab a11y label, theme-token thumb bg (PR #26 polish)

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -81,7 +81,7 @@
 
 .pc-thumb {
   position: relative; z-index: 2;        /* sit above the card's stretched title link so the image opens full */
-  align-self: stretch; min-height: 100%; overflow: hidden; background: #f6f7f9;
+  align-self: stretch; min-height: 100%; overflow: hidden; background: var(--bg);
   border-left: 1px solid var(--line);
 }
 .pc-thumb img {

--- a/blog.md
+++ b/blog.md
@@ -51,7 +51,7 @@ description: "System design write-ups, platform & AI engineering notes, and deep
     </div>
     {%- assign cover_img = post.thumbnail | default: post.image %}
     {%- if cover_img %}
-    <a class="pc-thumb" href="{{ cover_img | relative_url }}" target="_blank" rel="noopener" aria-label="Open the {{ post.title | escape }} diagram"><img src="{{ cover_img | relative_url }}" alt="{{ post.title | escape }} architecture diagram" loading="lazy"></a>
+    <a class="pc-thumb" href="{{ cover_img | relative_url }}" target="_blank" rel="noopener noreferrer" aria-label="Open diagram for {{ post.title | escape }} (opens in a new tab)"><img src="{{ cover_img | relative_url }}" alt="{{ post.title | escape }} architecture diagram" loading="lazy"></a>
     {%- else %}
     <a class="pc-thumb cover g{{ seed }}" href="{{ post.url | relative_url }}" tabindex="-1" aria-hidden="true">
       <span class="pc-cover-title">{{ post.title | escape }}</span>


### PR DESCRIPTION
Applies the two non-blocking Copilot polish suggestions deferred from #26 (branch was deleted, so re-routed as a fresh PR rather than a direct push to master):

1. **blog.md** (`.pc-thumb` anchor) — `rel="noopener"` → `rel="noopener noreferrer"`; aria-label now surfaces the new-tab behavior: `Open diagram for … (opens in a new tab)`.
2. **assets/css/blog.css** (`.pc-thumb` background) — hard-coded `#f6f7f9` → `var(--bg)` (`#f7f8fa`, visually identical) so the diagram backdrop tracks the theme palette.

Cosmetic / a11y polish only; no behavior change. Reviewed clean by the gatekeeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)