### PR TITLE
fix(blog): render §4 Entities as plain block + equalize card heights

### DIFF
--- a/_posts/2026-06-29-system-design-bitly.md
+++ b/_posts/2026-06-29-system-design-bitly.md
@@ -72,7 +72,7 @@ graph LR
 - 40B links × ~650 bytes/link → ~26TB of row data → any single-node DB is out; distributed store with partition-per-short-code is the only path
 ## 4. Entities & API
 
-```sql
+```
 URL {
   short_code:   string PK ← base62-encoded ID, 7 characters
   long_url:     string    ← canonicalized, max 2048 chars

--- a/_posts/2026-06-29-system-design-google-news.md
+++ b/_posts/2026-06-29-system-design-google-news.md
@@ -69,7 +69,7 @@ graph LR
 
 ## 4. Entities & API
 
-```sql
+```
 Article {
   article_id:      string PK       ← publisher domain + path hash, globally unique
   url:             string UNIQUE   ← canonical URL after normalization

--- a/_posts/2026-06-29-system-design-job-scheduler.md
+++ b/_posts/2026-06-29-system-design-job-scheduler.md
@@ -75,7 +75,7 @@ graph LR
 - ≤2s scheduling precision means the scheduling hot path can't wait on a DB poll. A `FOR UPDATE SKIP LOCKED` scan at 500ms intervals gives 250ms average precision but P99 spikes under DB load. Decision: **in-memory timing wheel** for the near-future window (next 15 min) with O(1) tick cost; fall back to DB polling for jobs farther out.
 ## 4. Entities & API
 
-```sql
+```
 task {
   task_id:        uuid PK
   name:           string

--- a/_posts/2026-06-29-system-design-local-delivery.md
+++ b/_posts/2026-06-29-system-design-local-delivery.md
@@ -69,7 +69,7 @@ graph LR
 
 ## 4. Entities & API
 
-```sql
+```
 DC {
   dc_id:             string PK    ← short code, e.g. "PHL-12"
   geo_hash:          string INDEX ← GeoHash-7 (~153m × 153m cell); spatial index key

--- a/_posts/2026-06-30-system-design-tinder.md
+++ b/_posts/2026-06-30-system-design-tinder.md
@@ -72,7 +72,7 @@ graph LR
 
 ## 4. Entities & API
 
-```sql
+```
 User {
   user_id:    string PK
   name:       string

--- a/_posts/2026-06-30-system-design-whatsapp.md
+++ b/_posts/2026-06-30-system-design-whatsapp.md
@@ -64,7 +64,7 @@ graph LR
 
 ## 4. Entities & API
 
-```sql
+```
 User {
   user_id:     uuid PK          ← globally unique, shard key
   phone:       string UNIQUE    ← hashed at rest

--- a/_posts/2026-06-30-yelp.md
+++ b/_posts/2026-06-30-yelp.md
@@ -71,7 +71,7 @@ graph LR
 
 ## 4. Entities & API
 
-```sql
+```
 Business {
   business_id:  uuid PK
   name:         string

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -73,6 +73,7 @@
    cover image to the rounded corners (no borders peeking, no overflow). */
 .post-card {
   position: relative; display: grid; grid-template-columns: minmax(0,1fr) 240px;
+  min-height: 208px;   /* uniform card height — the row is driven by the text column, never by a tall diagram thumb */
   background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
   overflow: hidden; box-shadow: var(--shadow);
   transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
@@ -85,7 +86,8 @@
   border-left: 1px solid var(--line);
 }
 .pc-thumb img {
-  width: 100%; height: 100%; object-fit: cover; object-position: center;
+  position: absolute; inset: 0;   /* out of flow: a tall (portrait) diagram can't dictate the row height */
+  width: 100%; height: 100%; object-fit: cover; object-position: top center;
   margin: 0; border: 0; border-radius: 0; display: block; transition: transform .4s ease;
 }
 .post-card:hover .pc-thumb img { transform: scale(1.05); }


### PR DESCRIPTION
## What

Two blog-rendering fixes from the Google News post.

### 1. §4 Entities block rendered as broken red "SQL"
The data model is a brace-block **pseudo-schema** fenced ` ```sql ` (so Notion highlights DB types). On the blog, Rouge's SQL lexer mangled it:
- An apostrophe in a `← comment` (`highest-authority source's headline`) opened an **unterminated string literal** that painted the entire rest of the block **red** (all of `Story`/`UserProfile`/`UserEvent`).
- Bare words (`language`, `domain`, `from`, `of`, `unique`) were miscolored as SQL keywords; `←` became error tokens.

It isn't SQL. Dropping the `sql` language tag renders it as a **clean, uniform monospace block** (`language-plaintext`, no tokenization). Applied to all 7 system-design posts. Real deep-dive SQL snippets (`INSERT … ON CONFLICT`) stay highlighted — only ` ```sql ` blocks containing an `EntityName {` brace line are down-converted.

The pipeline is fixed at the source too: `~/.hermes/scripts/jekyll-normalize.py` (fix #8) and the in-container `postprocess-sd-markdown.py` now do this automatically on every publish, so future designs never ship the red block.

### 2. Google News card taller than the rest
A tall (portrait) diagram thumbnail stretched its card far taller than the others. The `<img>` sat in flow inside a fixed 240px grid column, so its intrinsic aspect-scaled height drove the row. Fix: take the image out of flow (`position:absolute; inset:0`) so the row is sized by the text column like every other card, plus a `min-height` floor for uniform height.

## Verification
- Local `jekyll build`: entities block now `language-plaintext` (0 `language-sql`, no red string/err spans in that block); idempotent normalizer.