### PR TITLE
fix(blog): cache-bust card thumbnail URLs so re-rendered diagrams show

### DIFF
--- a/BLOG-AUTHORING.md
+++ b/BLOG-AUTHORING.md
@@ -160,3 +160,7 @@ back to the `## 1` overview) to `images/posts/<file>.svg` via kroki.io and write
   a diagram — so always run the script and confirm the `thumbnail:` line landed before publishing.
 - If the diagram fails to render (a Mermaid syntax error), **fix the diagram** and re-run with `--force` —
   don't ship the post on the gradient fallback.
+- **Overwriting a thumbnail is cache-safe.** `render-post-diagram.py --force` writes the new SVG to the
+  **same** `images/posts/<file>.svg` path. `blog.md` appends a build-time `?v=` to the card URL (same scheme
+  as CSS/JS), so each deploy serves a fresh URL — browsers and Cloudflare (`max-age=14400`) can't keep showing
+  a stale placeholder. Without that versioning a re-rendered diagram stays invisible for up to 4h behind cache.

--- a/blog.md
+++ b/blog.md
@@ -53,9 +53,14 @@ description: "System design write-ups, platform & AI engineering notes, and deep
         scripts/render-post-diagram.py. NEVER fall back to post.image — that is the site-wide
         og-default.png social card (set via _config.yml defaults) and would show the same banner
         on every post. No thumbnail → the gradient title-card below. {%- endcomment %}
+    {%- comment %} Cache-bust the thumbnail URL with the build timestamp (same ?v= scheme as CSS/JS
+        in the layouts). The pipeline OVERWRITES a post's thumbnail SVG in place when the diagram is
+        (re)rendered; without a versioned URL, browsers + Cloudflare keep serving the stale bytes
+        (max-age=14400) and the card shows an old placeholder even though the real diagram deployed. {%- endcomment %}
     {%- assign cover_img = post.thumbnail %}
     {%- if cover_img %}
-    <a class="pc-thumb" href="{{ cover_img | relative_url }}" target="_blank" rel="noopener noreferrer" aria-label="Open diagram for {{ post.title | escape }} (opens in a new tab)"><img src="{{ cover_img | relative_url }}" alt="{{ post.title | escape }} architecture diagram" loading="lazy"></a>
+    {%- assign cover_v = site.time | date: '%s' %}
+    <a class="pc-thumb" href="{{ cover_img | relative_url }}?v={{ cover_v }}" target="_blank" rel="noopener noreferrer" aria-label="Open diagram for {{ post.title | escape }} (opens in a new tab)"><img src="{{ cover_img | relative_url }}?v={{ cover_v }}" alt="{{ post.title | escape }} architecture diagram" loading="lazy"></a>
     {%- else %}
     <a class="pc-thumb cover g{{ seed }}" href="{{ post.url | relative_url }}" tabindex="-1" aria-hidden="true">
       <span class="pc-cover-title">{{ post.title | escape }}</span>


### PR DESCRIPTION
## Problem

The blog-index cards still showed the **old dark title-card placeholder** instead of each post's architecture diagram — even though the render pipeline was already correct.

**Root cause = stale HTTP cache, not the pipeline.** All 14 posts' thumbnail SVGs are the real §5 diagrams (verified). But PR #63 overwrote each thumbnail **in place** at the same URL, and browsers + Cloudflare (`Cache-Control: max-age=14400`, 4h) kept serving the cached old placeholder bytes. The correct diagram was deployed but invisible behind cache.

Confirmed live: a cache-busted fetch of `…rate-limiter.svg` returns the real 383×778 flowchart and renders fine in an `<img>`; the un-versioned card URL returns the stale placeholder from disk/CDN cache.

## Fix

Append the build timestamp as `?v=` to the card thumbnail `href` + `img src` in `blog.md`, mirroring the `?v={{ site.time }}` scheme the layouts already use for CSS/JS. Every deploy now yields a fresh thumbnail URL, so an overwritten diagram can never be masked by a cached placeholder again — browser or CDN. Also documented the cache-safety in `BLOG-AUTHORING.md §9`.

## Verification

- Built locally; card `img src` is now `…rate-limiter.svg?v=1782949089`.
- Served `_site` and confirmed the cards render the **real** Rate Limiter / News Feed / Google Docs architecture diagrams (screenshots taken).
- Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)