### PR TITLE
Add real diagram thumbnail to Strava post

### DIFF
--- a/_posts/2026-07-02-system-design-strava.md
+++ b/_posts/2026-07-02-system-design-strava.md
@@ -4,6 +4,7 @@ title: "System Design: Strava"
 date: 2026-07-02
 tags: [System Design, Strava]
 description: "Strava lets athletes record, share, and compete over GPS-tracked activities at a scale where 10 million runs and rides arrive every day."
+thumbnail: /images/posts/2026-07-02-system-design-strava.svg
 ---
 
 Strava lets athletes record, share, and compete over GPS-tracked activities at a scale where 10 million runs and rides arrive every day.


### PR DESCRIPTION
The Strava publish run set no `thumbnail:` -> the card fell to the gradient placeholder. Rendered the §5 HLD diagram via kroki as the thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)