### PR TITLE
Add a Designs section: system designs move to /designs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,11 +32,20 @@ linkedin_username: iliazlobin
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 header_pages:
   - resume.md
   - portfolio.md
+  - designs.md
   - blog.md
   - index.md
+
+# System-design write-ups live in their own /designs section (separate from the Blog, which is
+# for platform/AI engineering notes and deep dives). Each design is a page at /designs/<slug>/.
+collections:
+  designs:
+    output: true
+    permalink: /designs/:name/
 
 # --- Author & social (used by jekyll-seo-tag for meta + JSON-LD) ---
 author: Ilia Zlobin

--- a/_designs/online-auction.md
+++ b/_designs/online-auction.md
@@ -5,6 +5,8 @@ date: 2026-07-01
 tags: [System Design]
 description: "An online auction platform lets sellers list items with a starting price and end time, and buyers compete by placing ascending bids. The winner is the highest bidder at close."
 thumbnail: /images/posts/2026-07-01-online-auction.svg
+redirect_from:
+  - /2026/07/01/online-auction.html
 ---
 
 An online auction platform lets sellers list items with a starting price and end time, and buyers compete by placing ascending bids. The winner is the highest bidder at close.

--- a/_designs/system-design-ad-click-aggregator.md
+++ b/_designs/system-design-ad-click-aggregator.md
@@ -5,6 +5,8 @@ date: 2026-07-01
 tags: [System Design]
 description: "An ad platform processes clicks from millions of users across thousands of publisher sites."
 thumbnail: /images/posts/2026-07-01-system-design-ad-click-aggregator.svg
+redirect_from:
+  - /2026/07/01/system-design-ad-click-aggregator.html
 ---
 
 An ad platform processes clicks from millions of users across thousands of publisher sites.

--- a/_designs/system-design-bitly.md
+++ b/_designs/system-design-bitly.md
@@ -5,6 +5,8 @@ date: 2026-06-29
 tags: [System Design]
 description: "Bitly turns long URLs into short ones and tracks every click. It looks simple — take a URL, generate a 7-character code, store the mapping, redirect on lookup. But the real challenge is analytics: every redirect must record an event without slowing the redirect."
 thumbnail: /images/posts/2026-06-29-system-design-bitly.svg
+redirect_from:
+  - /2026/06/29/system-design-bitly.html
 ---
 
 Bitly turns long URLs into short ones and tracks every click. It looks simple — take a URL, generate a 7-character code, store the mapping, redirect on lookup. But the real challenge is analytics: every redirect must record an event without slowing the redirect.

--- a/_designs/system-design-camelcamelcamel.md
+++ b/_designs/system-design-camelcamelcamel.md
@@ -5,6 +5,8 @@ date: 2026-07-01
 tags: [System Design]
 description: "Design a price tracking service that lets users monitor product prices across online retailers, view historical price charts, and receive alerts when prices drop to a target threshold."
 thumbnail: /images/posts/2026-07-01-system-design-camelcamelcamel.svg
+redirect_from:
+  - /2026/07/01/system-design-camelcamelcamel.html
 ---
 
 Design a price tracking service that lets users monitor product prices across online retailers, view historical price charts, and receive alerts when prices drop to a target threshold.

--- a/_designs/system-design-distributed-cache.md
+++ b/_designs/system-design-distributed-cache.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "A single-node cache (one Redis instance, one Memcached process) hits a hard wall: the server's RAM ceiling."
 thumbnail: /images/posts/2026-07-02-system-design-distributed-cache.svg
+redirect_from:
+  - /2026/07/02/system-design-distributed-cache.html
 ---
 
 A single-node cache (one Redis instance, one Memcached process) hits a hard wall: the server's RAM ceiling.

--- a/_designs/system-design-dropbox.md
+++ b/_designs/system-design-dropbox.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "Dropbox is a cloud file storage and sync service serving 700M+ registered users with exabytes of stored content. Users upload files from any device, access them everywhere, share folders with collaborators, and recover previous versions."
 thumbnail: /images/posts/2026-07-02-system-design-dropbox.svg
+redirect_from:
+  - /2026/07/02/system-design-dropbox.html
 ---
 
 Dropbox is a cloud file storage and sync service serving 700M+ registered users with exabytes of stored content. Users upload files from any device, access them everywhere, share folders with collaborators, and recover previous versions.

--- a/_designs/system-design-google-docs.md
+++ b/_designs/system-design-google-docs.md
@@ -5,6 +5,8 @@ date: 2026-07-01
 tags: [System Design]
 description: "Google Docs serves ~2B monthly active users editing documents collaboratively in real time. A document open for editing draws 1–100 concurrent collaborators whose keystrokes must resolve to a single consistent document state with sub-200ms latency."
 thumbnail: /images/posts/2026-07-01-system-design-google-docs.svg
+redirect_from:
+  - /2026/07/01/system-design-google-docs.html
 ---
 
 Google Docs serves ~2B monthly active users editing documents collaboratively in real time. A document open for editing draws 1–100 concurrent collaborators whose keystrokes must resolve to a single consistent document state with sub-200ms latency.

--- a/_designs/system-design-google-news.md
+++ b/_designs/system-design-google-news.md
@@ -5,6 +5,8 @@ date: 2026-06-29
 tags: [System Design]
 description: "Google News aggregates articles from 50,000+ publishers worldwide, groups coverage of the same event into story clusters, and serves a ranked, personalized feed to over 150 million monthly users across 70+ regional editions in 30+ languages."
 thumbnail: /images/posts/2026-06-29-system-design-google-news.svg
+redirect_from:
+  - /2026/06/29/system-design-google-news.html
 ---
 
 Google News aggregates articles from 50,000+ publishers worldwide, groups coverage of the same event into story clusters, and serves a ranked, personalized feed to over 150 million monthly users across 70+ regional editions in 30+ languages.

--- a/_designs/system-design-instagram.md
+++ b/_designs/system-design-instagram.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "Instagram is a photo and video sharing platform where users post media, follow others, and scroll through a personalized feed."
 thumbnail: /images/posts/2026-07-02-system-design-instagram.svg
+redirect_from:
+  - /2026/07/02/system-design-instagram.html
 ---
 
 Instagram is a photo and video sharing platform where users post media, follow others, and scroll through a personalized feed.

--- a/_designs/system-design-job-scheduler.md
+++ b/_designs/system-design-job-scheduler.md
@@ -5,6 +5,8 @@ date: 2026-06-29
 tags: [System Design]
 description: "A job scheduler accepts one-shot and scheduled job submissions, executes them at the specified time, retries on failure, and surfaces execution history. Users submit, cancel, and monitor jobs through an API with no infrastructure management."
 thumbnail: /images/posts/2026-06-29-system-design-job-scheduler.svg
+redirect_from:
+  - /2026/06/29/system-design-job-scheduler.html
 ---
 
 A job scheduler accepts one-shot and scheduled job submissions, executes them at the specified time, retries on failure, and surfaces execution history. Users submit, cancel, and monitor jobs through an API with no infrastructure management.

--- a/_designs/system-design-leetcode.md
+++ b/_designs/system-design-leetcode.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "LeetCode serves ~300,000 registered users who practice coding on ~4,000 problems across 20+ languages. The platform also hosts weekly coding competitions drawing 100,000 concurrent contestants — a 30× traffic spike over baseline that lands in the first 60 seconds."
 thumbnail: /images/posts/2026-07-02-system-design-leetcode.svg
+redirect_from:
+  - /2026/07/02/system-design-leetcode.html
 ---
 
 LeetCode serves ~300,000 registered users who practice coding on ~4,000 problems across 20+ languages. The platform also hosts weekly coding competitions drawing 100,000 concurrent contestants — a 30× traffic spike over baseline that lands in the first 60 seconds.

--- a/_designs/system-design-local-delivery.md
+++ b/_designs/system-design-local-delivery.md
@@ -5,6 +5,8 @@ date: 2026-06-29
 tags: [System Design]
 description: "Local Delivery connects customers, restaurants, and couriers in a three-sided marketplace — a customer opens the app, searches for restaurants near their address, builds a cart from a live menu, and checks out."
 thumbnail: /images/posts/2026-06-29-system-design-local-delivery.svg
+redirect_from:
+  - /2026/06/29/system-design-local-delivery.html
 ---
 
 Local Delivery connects customers, restaurants, and couriers in a three-sided marketplace — a customer opens the app, searches for restaurants near their address, builds a cart from a live menu, and checks out.

--- a/_designs/system-design-netflix.md
+++ b/_designs/system-design-netflix.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "Netflix streams on-demand video to 325M+ paid subscribers across 190 countries, ingests 500+ hours of new content per minute, and serves ~15% of global internet downstream traffic."
 thumbnail: /images/posts/2026-07-02-system-design-netflix.svg
+redirect_from:
+  - /2026/07/02/system-design-netflix.html
 ---
 
 Netflix streams on-demand video to 325M+ paid subscribers across 190 countries, ingests 500+ hours of new content per minute, and serves ~15% of global internet downstream traffic.

--- a/_designs/system-design-online-chess.md
+++ b/_designs/system-design-online-chess.md
@@ -5,6 +5,8 @@ date: 2026-07-01
 tags: [System Design]
 description: "Online chess is a real-time two-player game where every half-second of latency feels like an eternity."
 thumbnail: /images/posts/2026-07-01-system-design-online-chess.svg
+redirect_from:
+  - /2026/07/01/system-design-online-chess.html
 ---
 
 Online chess is a real-time two-player game where every half-second of latency feels like an eternity.

--- a/_designs/system-design-payment-system.md
+++ b/_designs/system-design-payment-system.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "A payment system moves money from a customer's funding source to a merchant's account through payment service providers (PSPs) like Stripe and Adyen. The system authorizes funds, captures them, and records every movement in a double-entry ledger so the books balance to the cent."
 thumbnail: /images/posts/2026-07-02-system-design-payment-system.svg
+redirect_from:
+  - /2026/07/02/system-design-payment-system.html
 ---
 
 A payment system moves money from a customer's funding source to a merchant's account through payment service providers (PSPs) like Stripe and Adyen. The system authorizes funds, captures them, and records every movement in a double-entry ledger so the books balance to the cent.

--- a/_designs/system-design-post-search.md
+++ b/_designs/system-design-post-search.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "Post Search lets users find social media posts by keyword, phrase, or semantic meaning across billions of posts, returning ranked results in under 200ms. The system ingests millions of new posts per minute, indexes them in near real-time, and serves search traffic from a global user base."
 thumbnail: /images/posts/2026-07-02-system-design-post-search.svg
+redirect_from:
+  - /2026/07/02/system-design-post-search.html
 ---
 
 Post Search lets users find social media posts by keyword, phrase, or semantic meaning across billions of posts, returning ranked results in under 200ms. The system ingests millions of new posts per minute, indexes them in near real-time, and serves search traffic from a global user base.

--- a/_designs/system-design-rate-limiter.md
+++ b/_designs/system-design-rate-limiter.md
@@ -5,6 +5,8 @@ date: 2026-07-01
 tags: [System Design]
 description: "A rate limiter controls how many requests a client can make within a time window. It sits in the request path for every API call, enforcing configurable limits — per user, per IP, or per API key — and rejecting excess traffic with HTTP 429."
 thumbnail: /images/posts/2026-07-01-system-design-rate-limiter.svg
+redirect_from:
+  - /2026/07/01/system-design-rate-limiter.html
 ---
 
 A rate limiter controls how many requests a client can make within a time window. It sits in the request path for every API call, enforcing configurable limits — per user, per IP, or per API key — and rejecting excess traffic with HTTP 429.

--- a/_designs/system-design-strava.md
+++ b/_designs/system-design-strava.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "Strava lets athletes record, share, and compete over GPS-tracked activities at a scale where 10 million runs and rides arrive every day."
 thumbnail: /images/posts/2026-07-02-system-design-strava.svg
+redirect_from:
+  - /2026/07/02/system-design-strava.html
 ---
 
 Strava lets athletes record, share, and compete over GPS-tracked activities at a scale where 10 million runs and rides arrive every day.

--- a/_designs/system-design-ticketmaster.md
+++ b/_designs/system-design-ticketmaster.md
@@ -5,6 +5,8 @@ date: 2026-06-30
 tags: [System Design]
 description: "Ticketmaster sells 500M tickets a year across 30 countries as the dominant primary-ticketing marketplace. The hard problem is the flash onsale: 14M people compete for 60,000 seats when Taylor Swift or the Super Bowl goes on sale. Demand outstrips supply 83:1, browse traffic hits 2."
 thumbnail: /images/posts/2026-06-30-system-design-ticketmaster.svg
+redirect_from:
+  - /2026/06/30/system-design-ticketmaster.html
 ---
 
 Ticketmaster sells 500M tickets a year across 30 countries as the dominant primary-ticketing marketplace. The hard problem is the flash onsale: 14M people compete for 60,000 seats when Taylor Swift or the Super Bowl goes on sale. Demand outstrips supply 83:1, browse traffic hits 2.

--- a/_designs/system-design-tiktok-reels.md
+++ b/_designs/system-design-tiktok-reels.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "TikTok serves 71 billion video views daily to 1.9 billion monthly users, with 34 million new uploads flowing through a GPU transcoding pipeline every 24 hours."
 thumbnail: /images/posts/2026-07-02-system-design-tiktok-reels.svg
+redirect_from:
+  - /2026/07/02/system-design-tiktok-reels.html
 ---
 
 TikTok serves 71 billion video views daily to 1.9 billion monthly users, with 34 million new uploads flowing through a GPU transcoding pipeline every 24 hours.

--- a/_designs/system-design-tinder.md
+++ b/_designs/system-design-tinder.md
@@ -5,6 +5,8 @@ date: 2026-06-30
 tags: [System Design]
 description: "Tinder is a mobile dating app where users create profiles, set discovery preferences, and swipe through a stack of nearby profiles — right to like, left to pass. When two users mutually like each other, a match is formed and they can message."
 thumbnail: /images/posts/2026-06-30-system-design-tinder.svg
+redirect_from:
+  - /2026/06/30/system-design-tinder.html
 ---
 
 Tinder is a mobile dating app where users create profiles, set discovery preferences, and swipe through a stack of nearby profiles — right to like, left to pass. When two users mutually like each other, a match is formed and they can message.

--- a/_designs/system-design-top-k.md
+++ b/_designs/system-design-top-k.md
@@ -5,6 +5,8 @@ date: 2026-06-30
 tags: [System Design]
 description: "A video platform ingests view events at massive scale — 70 billion per day across billions of videos — and must surface the most-viewed videos per time window at sub-50ms read latency."
 thumbnail: /images/posts/2026-06-30-system-design-top-k.svg
+redirect_from:
+  - /2026/06/30/system-design-top-k.html
 ---
 
 A video platform ingests view events at massive scale — 70 billion per day across billions of videos — and must surface the most-viewed videos per time window at sub-50ms read latency.

--- a/_designs/system-design-uber.md
+++ b/_designs/system-design-uber.md
@@ -5,6 +5,8 @@ date: 2026-06-30
 tags: [System Design]
 description: "Uber connects 170M+ monthly active riders with 5M+ drivers across 10,000+ cities in 70+ countries, processing 15M+ daily trips."
 thumbnail: /images/posts/2026-06-30-system-design-uber.svg
+redirect_from:
+  - /2026/06/30/system-design-uber.html
 ---
 
 Uber connects 170M+ monthly active riders with 5M+ drivers across 10,000+ cities in 70+ countries, processing 15M+ daily trips.

--- a/_designs/system-design-web-crawler.md
+++ b/_designs/system-design-web-crawler.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design]
 description: "A web crawler that ingests ~10 billion web pages and extracts their text content to build an LLM training dataset. The crawl must complete in under 5 days, fetching pages from hundreds of millions of distinct hosts while respecting per-host rate limits and robots.txt."
 thumbnail: /images/posts/2026-07-02-system-design-web-crawler.svg
+redirect_from:
+  - /2026/07/02/system-design-web-crawler.html
 ---
 
 A web crawler that ingests ~10 billion web pages and extracts their text content to build an LLM training dataset. The crawl must complete in under 5 days, fetching pages from hundreds of millions of distinct hosts while respecting per-host rate limits and robots.txt.

--- a/_designs/system-design-whatsapp.md
+++ b/_designs/system-design-whatsapp.md
@@ -5,6 +5,8 @@ date: 2026-06-30
 tags: [System Design]
 description: "A global messaging platform serving 3B+ users who exchange over 100B messages and 10 PB of media daily."
 thumbnail: /images/posts/2026-06-30-system-design-whatsapp.svg
+redirect_from:
+  - /2026/06/30/system-design-whatsapp.html
 ---
 
 A global messaging platform serving 3B+ users who exchange over 100B messages and 10 PB of media daily.

--- a/_designs/system-design-youtube.md
+++ b/_designs/system-design-youtube.md
@@ -5,6 +5,8 @@ date: 2026-06-30
 tags: [System Design]
 description: "YouTube ingests over 70 billion view events per day across more than 4 billion distinct videos, serving over 500 million daily active users who watch over a billion hours of content."
 thumbnail: /images/posts/2026-06-30-system-design-youtube.svg
+redirect_from:
+  - /2026/06/30/system-design-youtube.html
 ---
 
 YouTube ingests over 70 billion view events per day across more than 4 billion distinct videos, serving over 500 million daily active users who watch over a billion hours of content.

--- a/_designs/yelp.md
+++ b/_designs/yelp.md
@@ -5,6 +5,8 @@ date: 2026-06-30
 tags: [System Design]
 description: "Yelp is a local business discovery platform connecting ~74M monthly visitors with ~8.4M businesses across categories like restaurants, home services, and retail. Users search by location and keyword, browse ~330M reviews and ~500M photos, and contribute their own ratings and content."
 thumbnail: /images/posts/2026-06-30-yelp.svg
+redirect_from:
+  - /2026/06/30/yelp.html
 ---
 
 Yelp is a local business discovery platform connecting ~74M monthly visitors with ~8.4M businesses across categories like restaurants, home services, and retail. Users search by location and keyword, browse ~330M reviews and ~500M photos, and contribute their own ratings and content.

--- a/designs.md
+++ b/designs.md
@@ -1,22 +1,25 @@
 ---
 layout: page
-title: Blog
-permalink: /blog/
-description: "Platform & AI engineering notes, build logs, and deep dives by Ilia Zlobin. System design write-ups live under Designs."
+title: Designs
+permalink: /designs/
+description: "System design write-ups by Ilia Zlobin — production-grade architectures with diagrams, data models, deep dives, and trade-offs."
 ---
 
 <link rel="stylesheet" href="{{ '/assets/css/blog.css' | relative_url }}?v={{ site.time | date: '%s' }}">
 
-<p class="blog-intro">Platform &amp; AI engineering notes, build logs, and deep dives. (System design write-ups live under <a href="{{ '/designs/' | relative_url }}">Designs</a>.)</p>
+<p class="blog-intro">System design write-ups — production-grade architectures, section for section: requirements, back-of-the-envelope, data model, high-level design, and the deep dives. Diagrams and code throughout.</p>
 
-{%- if site.posts.size > 0 %}
-{%- assign by_year = site.posts | group_by_exp: "p", "p.date | date: '%Y'" %}
+{%- if site.designs.size > 0 %}
+{%- assign sorted = site.designs | sort: "date" | reverse %}
+{%- assign by_year = sorted | group_by_exp: "p", "p.date | date: '%Y'" %}
+{%- assign flat_tags = site.designs | map: "tags" | join: "|" | split: "|" %}
+{%- assign grouped_tags = flat_tags | group_by_exp: "t", "t" %}
 
 <div class="blog-controls" data-blog-filter>
   <div class="tag-input" data-tag-input>
     <svg class="ti-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>
     <span class="ti-tokens"></span>
-    <input type="text" class="ti-field" placeholder="Filter by topic…" aria-label="Filter posts by topic" autocomplete="off" spellcheck="false">
+    <input type="text" class="ti-field" placeholder="Filter by topic…" aria-label="Filter designs by topic" autocomplete="off" spellcheck="false">
     <div class="ti-suggest" hidden role="listbox" aria-label="Tag suggestions"></div>
   </div>
   <div class="bc-right">
@@ -24,7 +27,7 @@ description: "Platform & AI engineering notes, build logs, and deep dives by Ili
     <button class="ti-clear" data-tag-clear type="button" hidden>Clear all</button>
   </div>
 </div>
-<script type="application/json" data-blog-tags>[{% for t in site.tags %}{"name": {{ t[0] | jsonify | replace: '</', '<\/' }}, "count": {{ t[1].size }}}{% unless forloop.last %},{% endunless %}{% endfor %}]</script>
+<script type="application/json" data-blog-tags>[{% for t in grouped_tags %}{"name": {{ t.name | jsonify | replace: '</', '<\/' }}, "count": {{ t.items.size }}}{% unless forloop.last %},{% endunless %}{% endfor %}]</script>
 
 <div class="post-feed" data-blog-feed>
   {%- for yg in by_year %}
@@ -33,7 +36,7 @@ description: "Platform & AI engineering notes, build logs, and deep dives by Ili
   {%- assign words = post.content | number_of_words %}
   {%- assign minutes = words | divided_by: 200 | plus: 1 %}
   {%- assign seed = post.title | size | modulo: 6 %}
-  {%- assign primary = post.tags | first | default: "Post" %}
+  {%- assign primary = post.tags | first | default: "System Design" %}
   <div class="tl-item" data-tags="{{ post.tags | join: '|' | escape }}">
   <article class="post-card">
     <div class="pc-body">
@@ -45,18 +48,10 @@ description: "Platform & AI engineering notes, build logs, and deep dives by Ili
       <p>{{ post.excerpt | strip_html | truncatewords: 28 }}</p>
       {%- if post.tags.size > 0 %}
       <div class="pc-tags">
-        {%- for tag in post.tags %}<a class="tag" href="{{ '/blog/' | relative_url }}?tag={{ tag | url_encode }}" data-tag="{{ tag | escape }}">{{ tag }}</a>{% endfor %}
+        {%- for tag in post.tags %}<a class="tag" href="{{ '/designs/' | relative_url }}?tag={{ tag | url_encode }}" data-tag="{{ tag | escape }}">{{ tag }}</a>{% endfor %}
       </div>
       {%- endif %}
     </div>
-    {%- comment %} Card thumbnail = the post's own rendered diagram (post.thumbnail), set by
-        scripts/render-post-diagram.py. NEVER fall back to post.image — that is the site-wide
-        og-default.png social card (set via _config.yml defaults) and would show the same banner
-        on every post. No thumbnail → the gradient title-card below. {%- endcomment %}
-    {%- comment %} Cache-bust the thumbnail URL with the build timestamp (same ?v= scheme as CSS/JS
-        in the layouts). The pipeline OVERWRITES a post's thumbnail SVG in place when the diagram is
-        (re)rendered; without a versioned URL, browsers + Cloudflare keep serving the stale bytes
-        (max-age=14400) and the card shows an old placeholder even though the real diagram deployed. {%- endcomment %}
     {%- assign cover_img = post.thumbnail %}
     {%- if cover_img %}
     {%- assign cover_v = site.time | date: '%s' %}
@@ -73,7 +68,7 @@ description: "Platform & AI engineering notes, build logs, and deep dives by Ili
   {%- endfor %}
 </div>
 
-<p class="no-results" hidden>No posts match that filter. <button class="link-btn" data-filter-clear type="button">Clear filter</button></p>
+<p class="no-results" hidden>No designs match that filter. <button class="link-btn" data-filter-clear type="button">Clear filter</button></p>
 {%- else %}
-<p>No posts here yet — engineering notes and build logs landing soon. Meanwhile, the <a href="{{ '/designs/' | relative_url }}">Designs</a> section has the full system-design write-ups.</p>
+<p>No designs yet — first write-ups landing soon.</p>
 {%- endif %}


### PR DESCRIPTION
System-design write-ups now live in their own **/designs** section, separate from the Blog. Nav: Resume · Portfolio · **Designs** · Blog · About.

- New Jekyll collection `_designs` (permalink `/designs/<slug>/`).
- All 27 design posts moved `_posts` → `_designs`; each carries `redirect_from` its old `/YYYY/MM/DD/slug.html` URL (via `jekyll-redirect-from`), so existing links and the Content Tracker `Published URL`s keep resolving.
- New `designs.md` index (mirrors the blog timeline + tag filter, scoped to the designs collection).
- `blog.md` now scopes to non-design content (engineering notes, build logs) and links to /designs.

**Verified** with a local `jekyll build`: the /designs index and all 27 `/designs/<slug>/` pages render (7 sections, mermaid diagrams, thumbnails), redirect stubs emit for the old URLs, and the Blog feed is empty of designs.

Companion Notion/pipeline changes (Content Tracker `Category` column, publish routing by category) follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGo6LghDEDVhM3eFMYJuTQ