### PR TITLE
Designs: switch to the Portfolio layout (rail + big diagram cards, no stars/dates)

### DIFF
--- a/_designs/system-design-stock-trading-platform.md
+++ b/_designs/system-design-stock-trading-platform.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design, Trading, Finance, Real-time]
 description: "Stock trading platforms connect 23M+ retail investors to US equity markets, routing 15M orders a day through market makers and exchanges. Unlike an exchange — which maintains its own order book and matches buyers against sellers — a brokerage is a custody-and-routing layer."
 thumbnail: /images/posts/2026-07-02-system-design-stock-trading-platform.svg
+redirect_from:
+  - /2026/07/02/system-design-stock-trading-platform.html
 ---
 
 Stock trading platforms connect 23M+ retail investors to US equity markets, routing 15M orders a day through market makers and exchanges. Unlike an exchange — which maintains its own order book and matches buyers against sellers — a brokerage is a custody-and-routing layer.

--- a/designs.md
+++ b/designs.md
@@ -43,7 +43,7 @@ description: "System design write-ups by Ilia Zlobin — production-grade archit
       <h3><a href="{{ d.url | relative_url }}">{{ name | escape }}</a></h3>
       <p>{{ d.description | default: d.excerpt | strip_html | truncatewords: 46 }}</p>
       {%- if d.tags.size > 0 %}
-      <ul class="tags">{% for tag in d.tags %}<li>{{ tag }}</li>{% endfor %}</ul>
+      <ul class="tags">{% for tag in d.tags %}<li>{{ tag | escape }}</li>{% endfor %}</ul>
       {%- endif %}
       <div class="links"><a class="gh" href="{{ d.url | relative_url }}">Read the design →</a></div>
     </div>

--- a/designs.md
+++ b/designs.md
@@ -5,70 +5,52 @@ permalink: /designs/
 description: "System design write-ups by Ilia Zlobin — production-grade architectures with diagrams, data models, deep dives, and trade-offs."
 ---
 
-<link rel="stylesheet" href="{{ '/assets/css/blog.css' | relative_url }}?v={{ site.time | date: '%s' }}">
+<link rel="stylesheet" href="{{ '/assets/css/portfolio.css' | relative_url }}?v={{ site.time | date: '%s' }}">
+<style>
+  /* Designs reuse the Portfolio layout; the card title is a link to the write-up, so keep it
+     reading as a heading (not default link-blue) and only tint on hover. */
+  .portfolio-item h3 a { color: inherit; text-decoration: none; }
+  .portfolio-item h3 a:hover { color: var(--accent); }
+</style>
 
-<p class="blog-intro">System design write-ups — production-grade architectures, section for section: requirements, back-of-the-envelope, data model, high-level design, and the deep dives. Diagrams and code throughout.</p>
+<p class="portfolio-intro">System design write-ups — production-grade architectures, section for section: requirements, back-of-the-envelope estimates, data model, high-level design, and the deep dives. Diagrams and code throughout.</p>
 
-{%- if site.designs.size > 0 %}
-{%- assign sorted = site.designs | sort: "date" | reverse %}
-{%- assign by_year = sorted | group_by_exp: "p", "p.date | date: '%Y'" %}
-{%- assign flat_tags = site.designs | map: "tags" | join: "|" | split: "|" %}
-{%- assign grouped_tags = flat_tags | group_by_exp: "t", "t" %}
+{%- assign designs = site.designs | sort: "date" | reverse %}
+{%- if designs.size > 0 %}
+<div class="portfolio-layout">
 
-<div class="blog-controls" data-blog-filter>
-  <div class="tag-input" data-tag-input>
-    <svg class="ti-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>
-    <span class="ti-tokens"></span>
-    <input type="text" class="ti-field" placeholder="Filter by topic…" aria-label="Filter designs by topic" autocomplete="off" spellcheck="false">
-    <div class="ti-suggest" hidden role="listbox" aria-label="Tag suggestions"></div>
-  </div>
-  <div class="bc-right">
-    <span class="result-count" data-result-count></span>
-    <button class="ti-clear" data-tag-clear type="button" hidden>Clear all</button>
-  </div>
-</div>
-<script type="application/json" data-blog-tags>[{% for t in grouped_tags %}{"name": {{ t.name | jsonify | replace: '</', '<\/' }}, "count": {{ t.items.size }}}{% unless forloop.last %},{% endunless %}{% endfor %}]</script>
+<aside class="portfolio-rail">
+  <div class="rail-title">Designs</div>
+  <nav>
+    {%- for d in designs %}
+    {%- assign name = d.title | remove_first: "System Design: " %}
+    <a href="#{{ d.title | slugify }}" data-spy><span class="nm">{{ name | escape }}</span></a>
+    {%- endfor %}
+  </nav>
+</aside>
 
-<div class="post-feed" data-blog-feed>
-  {%- for yg in by_year %}
-  <div class="year-divider" id="y-{{ yg.name }}"><span>{{ yg.name }}</span></div>
-  {%- for post in yg.items %}
-  {%- assign words = post.content | number_of_words %}
-  {%- assign minutes = words | divided_by: 200 | plus: 1 %}
-  {%- assign seed = post.title | size | modulo: 6 %}
-  {%- assign primary = post.tags | first | default: "System Design" %}
-  <div class="tl-item" data-tags="{{ post.tags | join: '|' | escape }}">
-  <article class="post-card">
-    <div class="pc-body">
-      <div class="meta">
-        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
-        <span class="dot">·</span><span>{{ minutes }} min read</span>
-      </div>
-      <h3><a class="pc-title-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a></h3>
-      <p>{{ post.excerpt | strip_html | truncatewords: 28 }}</p>
-      {%- if post.tags.size > 0 %}
-      <div class="pc-tags">
-        {%- for tag in post.tags %}<a class="tag" href="{{ '/designs/' | relative_url }}?tag={{ tag | url_encode }}" data-tag="{{ tag | escape }}">{{ tag }}</a>{% endfor %}
-      </div>
-      {%- endif %}
-    </div>
-    {%- assign cover_img = post.thumbnail %}
-    {%- if cover_img %}
-    {%- assign cover_v = site.time | date: '%s' %}
-    <a class="pc-thumb" href="{{ cover_img | relative_url }}?v={{ cover_v }}" target="_blank" rel="noopener noreferrer" aria-label="Open diagram for {{ post.title | escape }} (opens in a new tab)"><img src="{{ cover_img | relative_url }}?v={{ cover_v }}" alt="{{ post.title | escape }} architecture diagram" loading="lazy"></a>
+<div class="portfolio-feed">
+  {%- for d in designs %}
+  {%- assign name = d.title | remove_first: "System Design: " %}
+  {%- assign seed = d.title | size | modulo: 6 %}
+  <article id="{{ d.title | slugify }}" class="portfolio-item reveal">
+    {%- if d.thumbnail %}
+    <a class="thumb" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><img src="{{ d.thumbnail | relative_url }}?v={{ site.time | date: '%s' }}" alt="{{ name | escape }} architecture diagram" loading="lazy"></a>
     {%- else %}
-    <a class="pc-thumb cover g{{ seed }}" href="{{ post.url | relative_url }}" tabindex="-1" aria-hidden="true">
-      <span class="pc-cover-title">{{ post.title | escape }}</span>
-      <span class="pc-cover-topic">{{ primary }}</span>
-    </a>
+    <a class="thumb placeholder g{{ seed }}" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><span>{{ name | escape }}</span></a>
     {%- endif %}
+    <div class="body">
+      <h3><a href="{{ d.url | relative_url }}">{{ name | escape }}</a></h3>
+      <p>{{ d.description | default: d.excerpt | strip_html | truncatewords: 46 }}</p>
+      {%- if d.tags.size > 0 %}
+      <ul class="tags">{% for tag in d.tags %}<li>{{ tag }}</li>{% endfor %}</ul>
+      {%- endif %}
+      <div class="links"><a class="gh" href="{{ d.url | relative_url }}">Read the design →</a></div>
+    </div>
   </article>
-  </div>
-  {%- endfor %}
   {%- endfor %}
 </div>
-
-<p class="no-results" hidden>No designs match that filter. <button class="link-btn" data-filter-clear type="button">Clear filter</button></p>
+</div>
 {%- else %}
 <p>No designs yet — first write-ups landing soon.</p>
 {%- endif %}


### PR DESCRIPTION
Per request — the **/designs** index now uses the same two-column **Portfolio layout**: a sticky rail of design names on the left, large cards with the architecture diagram + title + description + tags on the right. **No favourite stars, no dates.**

- Generated dynamically from the `_designs` collection (reuses `portfolio.css` + `site.js` scroll-spy/reveal — no new assets).
- Titles drop the `System Design: ` prefix for clean rail/card headings ("Web Crawler", "TikTok/Reels").
- Card title, thumbnail, and "Read the design →" all link to `/designs/<slug>/`.
- Also moved the Stock Trading Platform post (the automation re-added it to `_posts` via #89, before /designs existed) into `_designs`.

Verified with a local `jekyll build`: 28 rail items + 28 cards, **0 stars, 0 date badges**, titles prefix-stripped, all links → `/designs/<slug>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGo6LghDEDVhM3eFMYJuTQ