### PR TITLE
Designs: move Twitter/X + News Feed into _designs (all 30 designs under /designs)

### DIFF
--- a/_designs/system-design-news-feed.md
+++ b/_designs/system-design-news-feed.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design, Social Media, Feed]
 description: "A social media news feed must distribute every post to every follower, rank millions of candidate posts per user by predicted engagement, and serve the result in under 500ms — across 2B+ monthly active users."
 thumbnail: /images/posts/2026-07-02-system-design-news-feed.svg
+redirect_from:
+  - /2026/07/02/system-design-news-feed.html
 ---
 
 A social media news feed must distribute every post to every follower, rank millions of candidate posts per user by predicted engagement, and serve the result in under 500ms — across 2B+ monthly active users.

--- a/_designs/system-design-twitter-x.md
+++ b/_designs/system-design-twitter-x.md
@@ -5,6 +5,8 @@ date: 2026-07-02
 tags: [System Design, Social Media, Real-time]
 description: "Design a real-time social platform supporting 330M MAU that lets users post tweets (text + media), build timelines of tweets from followed users, search across all public tweets in real time, and discover trending topics."
 thumbnail: /images/posts/2026-07-02-system-design-twitter-x.svg
+redirect_from:
+  - /2026/07/02/system-design-twitter-x.html
 ---
 
 Design a real-time social platform supporting 330M MAU that lets users post tweets (text + media), build timelines of tweets from followed users, search across all public tweets in real time, and discover trending topics.


### PR DESCRIPTION
The automation re-published **Twitter/X** (#90) and **News Feed** (#91) into `_posts` (the Blog) before the /designs split settled, so they appeared as designs in the Blog. This moves both into `_designs` (date-less, with `redirect_from` their old URLs), so **all 30 system designs live under /designs** and the Blog is empty of designs. Also re-applies the tag `escape` fix that got stranded after #93 auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGo6LghDEDVhM3eFMYJuTQ