### PR TITLE
designs: drop .reveal so the card feed is visible (fade-in was stuck at opacity 0)

### DIFF
--- a/designs.md
+++ b/designs.md
@@ -33,7 +33,7 @@ description: "System design write-ups by Ilia Zlobin — production-grade archit
   {%- for d in designs %}
   {%- assign name = d.title | remove_first: "System Design: " %}
   {%- assign seed = d.title | size | modulo: 6 %}
-  <article id="{{ d.title | slugify }}" class="portfolio-item reveal">
+  <article id="{{ d.title | slugify }}" class="portfolio-item">
     {%- if d.thumbnail %}
     <a class="thumb" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><img src="{{ d.thumbnail | relative_url }}?v={{ site.time | date: '%s' }}" alt="{{ name | escape }} architecture diagram" loading="lazy"></a>
     {%- else %}


### PR DESCRIPTION
On /designs the `.reveal` fade-in stayed at `opacity:0` even after `site.js` added `.is-visible` — the reveal CSS didn't resolve on this collection page, so the whole card feed rendered blank while only the rail showed. The design cards don't need the scroll-in animation, so I removed `reveal`; the rail + big-diagram cards now show immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGo6LghDEDVhM3eFMYJuTQ