### PR TITLE
designs: MVP button only for public, existing repos (no 404 links)

### DIFF
--- a/_designs/system-design-ad-click-aggregator.md
+++ b/_designs/system-design-ad-click-aggregator.md
@@ -7,7 +7,6 @@ description: "An ad platform processes clicks from millions of users across thou
 thumbnail: /images/posts/2026-07-01-system-design-ad-click-aggregator.svg
 redirect_from:
   - /2026/07/01/system-design-ad-click-aggregator.html
-mvp_repo: https://github.com/iliazlobin/sd-ad-click-aggregator-backend-mvp
 ---
 
 An ad platform processes clicks from millions of users across thousands of publisher sites.

--- a/_designs/system-design-google-docs.md
+++ b/_designs/system-design-google-docs.md
@@ -7,7 +7,6 @@ description: "Google Docs serves ~2B monthly active users editing documents coll
 thumbnail: /images/posts/2026-07-01-system-design-google-docs.svg
 redirect_from:
   - /2026/07/01/system-design-google-docs.html
-mvp_repo: https://github.com/iliazlobin/sd-google-docs-backend-mvp
 ---
 
 Google Docs serves ~2B monthly active users editing documents collaboratively in real time. A document open for editing draws 1–100 concurrent collaborators whose keystrokes must resolve to a single consistent document state with sub-200ms latency.

--- a/_designs/system-design-online-chess.md
+++ b/_designs/system-design-online-chess.md
@@ -7,7 +7,6 @@ description: "Online chess is a real-time two-player game where every half-secon
 thumbnail: /images/posts/2026-07-01-system-design-online-chess.svg
 redirect_from:
   - /2026/07/01/system-design-online-chess.html
-mvp_repo: https://github.com/iliazlobin/sd-online-chess-backend-mvp
 ---
 
 Online chess is a real-time two-player game where every half-second of latency feels like an eternity.

--- a/_designs/system-design-rate-limiter.md
+++ b/_designs/system-design-rate-limiter.md
@@ -7,7 +7,6 @@ description: "A rate limiter controls how many requests a client can make within
 thumbnail: /images/posts/2026-07-01-system-design-rate-limiter.svg
 redirect_from:
   - /2026/07/01/system-design-rate-limiter.html
-mvp_repo: https://github.com/iliazlobin/sd-rate-limiter-backend-mvp
 ---
 
 A rate limiter controls how many requests a client can make within a time window. It sits in the request path for every API call, enforcing configurable limits — per user, per IP, or per API key — and rejecting excess traffic with HTTP 429.

--- a/_designs/system-design-stock-trading-platform.md
+++ b/_designs/system-design-stock-trading-platform.md
@@ -7,7 +7,6 @@ description: "Stock trading platforms connect 23M+ retail investors to US equity
 thumbnail: /images/posts/system-design-stock-trading-platform.svg
 redirect_from:
   - /2026/07/02/system-design-stock-trading-platform.html
-mvp_repo: https://github.com/iliazlobin/sd-stock-trading-platform-backend-mvp
 ---
 
 Stock trading platforms connect 23M+ retail investors to US equity markets, routing 15M orders a day through market makers and exchanges. Unlike an exchange — which maintains its own order book and matches buyers against sellers — a brokerage is a custody-and-routing layer.

--- a/_designs/system-design-web-crawler.md
+++ b/_designs/system-design-web-crawler.md
@@ -7,7 +7,6 @@ description: "A web crawler that ingests ~10 billion web pages and extracts thei
 thumbnail: /images/posts/2026-07-02-system-design-web-crawler.svg
 redirect_from:
   - /2026/07/02/system-design-web-crawler.html
-mvp_repo: https://github.com/iliazlobin/sd-web-crawler-backend-mvp
 ---
 
 A web crawler that ingests ~10 billion web pages and extracts their text content to build an LLM training dataset. The crawl must complete in under 5 days, fetching pages from hundreds of millions of distinct hosts while respecting per-host rate limits and robots.txt.


### PR DESCRIPTION
The MVP Repo backfill pulled URLs straight from the Projects DB, but some repos are **private** (404 for public visitors) and two **don't exist yet** (rate-limiter, web-crawler) — linking them gave broken buttons on a public portfolio.

Now the **GitHub MVP** button shows only for the **21** designs whose MVP repo is public + resolvable. Removed the front-matter `mvp_repo` for the 4 private + 2 missing. The 4 private MVPs stay tracked in the Content Tracker (the MVP exists — make the repo public to surface the button); the 2 missing were cleared from the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGo6LghDEDVhM3eFMYJuTQ