### PR TITLE
designs: re-add MVP buttons for Stock Trading + Online Chess (repos now public)

### DIFF
--- a/_designs/system-design-online-chess.md
+++ b/_designs/system-design-online-chess.md
@@ -5,6 +5,7 @@ date: 2026-07-01
 tags: [System Design]
 description: "Online chess is a real-time two-player game where every half-second of latency feels like an eternity."
 thumbnail: /images/posts/2026-07-01-system-design-online-chess.svg
+mvp_repo: https://github.com/iliazlobin/sd-online-chess-backend-mvp
 redirect_from:
   - /2026/07/01/system-design-online-chess.html
 ---

--- a/_designs/system-design-stock-trading-platform.md
+++ b/_designs/system-design-stock-trading-platform.md
@@ -5,6 +5,7 @@ date: 2026-07-02
 tags: [System Design, Trading, Finance, Real-time]
 description: "Stock trading platforms connect 23M+ retail investors to US equity markets, routing 15M orders a day through market makers and exchanges. Unlike an exchange — which maintains its own order book and matches buyers against sellers — a brokerage is a custody-and-routing layer."
 thumbnail: /images/posts/system-design-stock-trading-platform.svg
+mvp_repo: https://github.com/iliazlobin/sd-stock-trading-platform-backend-mvp
 redirect_from:
   - /2026/07/02/system-design-stock-trading-platform.html
 ---


### PR DESCRIPTION
Their MVP repos were made public, so the buttons resolve for visitors now. 23 public MVP buttons total. Google Docs + Ad Click Aggregator remain private (no button until public); Rate Limiter + Web Crawler MVP repos don't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGo6LghDEDVhM3eFMYJuTQ