### PR TITLE
designs: re-add MVP buttons for Google Docs + Ad Click Aggregator (now public)

### DIFF
--- a/_designs/system-design-ad-click-aggregator.md
+++ b/_designs/system-design-ad-click-aggregator.md
@@ -5,6 +5,7 @@ date: 2026-07-01
 tags: [System Design]
 description: "An ad platform processes clicks from millions of users across thousands of publisher sites."
 thumbnail: /images/posts/2026-07-01-system-design-ad-click-aggregator.svg
+mvp_repo: https://github.com/iliazlobin/sd-ad-click-aggregator-backend-mvp
 redirect_from:
   - /2026/07/01/system-design-ad-click-aggregator.html
 ---

--- a/_designs/system-design-google-docs.md
+++ b/_designs/system-design-google-docs.md
@@ -5,6 +5,7 @@ date: 2026-07-01
 tags: [System Design]
 description: "Google Docs serves ~2B monthly active users editing documents collaboratively in real time. A document open for editing draws 1–100 concurrent collaborators whose keystrokes must resolve to a single consistent document state with sub-200ms latency."
 thumbnail: /images/posts/2026-07-01-system-design-google-docs.svg
+mvp_repo: https://github.com/iliazlobin/sd-google-docs-backend-mvp
 redirect_from:
   - /2026/07/01/system-design-google-docs.html
 ---


### PR DESCRIPTION
## Summary
- Two MVP repos (Google Docs, Ad Click Aggregator) were flipped private → public.
- Restores their `mvp_repo:` front matter so the "GitHub MVP" button reappears on the design card + page.
- 25 designs now have a live, public-repo MVP button (up from 23).

## Test plan
- [x] `bundle exec jekyll build` — 25 "GitHub MVP" links on `/designs`, 1 `mvp-btn` on each design page.
- [x] Both repos confirmed public via `gh api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)