### PR TITLE
designs: fix ```plain text fences that broke kramdown rendering

### DIFF
--- a/_designs/harmful-content-detection.md
+++ b/_designs/harmful-content-detection.md
@@ -162,7 +162,7 @@ The production model is a multi-modal transformer inspired by FLAVA and Meta's W
 
 **Loss function**
 
-```plain text
+```text
 L = α · L_BCE_view_weighted + β · L_reports_prediction
 
 ```
@@ -174,7 +174,7 @@ L = α · L_BCE_view_weighted + β · L_reports_prediction
 
 **Why cross-attention over late fusion?**
 
-```plain text
+```text
                     | Late Fusion                                                     | Cross-Attention (chosen)                                                                                                          
 --------------------|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------
 Pro                 | Simple, fast, each encoder can be pre-trained independently     | Captures cross-modal interactions ("benign text + benign image = harmful meme")                                                   
@@ -189,7 +189,7 @@ Production evidence | —                                                       
 
 ### 7.1 Offline Training Pipeline
 
-```plain text
+```text
 Feature Computation → Training → Evaluation → Model Registry
 
 ```
@@ -212,7 +212,7 @@ Trained models stored in a model registry (MLflow or internal equivalent) with m
 
 ### 7.2 Online Serving Pipeline
 
-```plain text
+```text
 Upload → Feature Fetch → 2-Stage Inference → Action Layer
 
 ```
@@ -248,7 +248,7 @@ CSAM override: any CSAM head score above 0.1 triggers immediate removal and lega
 
 #### Serving-scale numbers
 
-```plain text
+```text
 Metric                | Value      | Notes                                
 ----------------------|------------|--------------------------------------
 Steady-state QPS      | ~12K       | 1B posts/day ÷ 86,400 seconds        
@@ -382,7 +382,7 @@ graph TD
 
 **Rationale grounded in production.** Every major platform uses this pattern. Google's Perspective API distilled BERT → CNN per language before moving to Charformer. YouTube uses hash matching → ML classifiers → human review (96.4% auto-flagged, cascaded). Reddit's LLM Guardrails Service achieves F1 0.97 at sub-25ms p99 latency. The key isn't whether to cascade — it's setting the Stage 1 threshold correctly.
 
-```plain text
+```text
 Stage       | Model                   | Params | Hardware | Latency   | Traffic Exit | Daily Cost
 ------------|-------------------------|--------|----------|-----------|--------------|-----------
 Stage 1     | Distilled MLP           | 0.5M   | CPU      | <10ms     | 95%          | ~$50      

--- a/_designs/system-design-instagram.md
+++ b/_designs/system-design-instagram.md
@@ -353,7 +353,7 @@ Store each edge on the shard owned by the edge ID. Both directions require scatt
 
 **TAO cache hierarchy:**
 
-```plain text
+```text
 Client → TAO Cache (in-process, LRU, 96% hit)
        → TAO Server (in-memory assoc list, sharded)
        → MySQL (persistent, async replication)

--- a/_designs/system-design-payment-system.md
+++ b/_designs/system-design-payment-system.md
@@ -334,7 +334,7 @@ BEGIN;
 COMMIT;
 ```
 
-```plain text
+```text
 Worker loop (runs every 1 second):
   SELECT * FROM outbox WHERE processed_at IS NULL ORDER BY created_at LIMIT 10;
   FOR EACH row:
@@ -418,7 +418,7 @@ FOR EACH ROW
 EXECUTE FUNCTION verify_batch_balance();
 ```
 
-```plain text
+```text
 verify_batch_balance():
   SELECT batch_id,
          SUM(amount) FILTER (WHERE side = 'debit')  AS debits,
@@ -464,7 +464,7 @@ Rationale: The ledger is the system of record for money. A bug that violates the
 
 **Approach 1: Row-by-row matching with tolerance**
 
-```plain text
+```text
 Reconciliation loop (runs hourly):
   report = fetch_settlement_report(psp, date_from, date_to)
   FOR EACH row IN report:
@@ -486,7 +486,7 @@ Reconciliation loop (runs hourly):
 
 **Approach 2: Hash-based batch reconciliation**
 
-```plain text
+```text
 internal_hash = MD5(
   SELECT string_agg(intent_id || ':' || amount::text, ',' ORDER BY created_at)
   FROM ledger_entries WHERE created_at BETWEEN $1 AND $2


### PR DESCRIPTION
## Problem

`iliazlobin.com/designs/harmful-content-detection/` (and 2 other designs) rendered broken: bold labels appeared inside gray code boxes, a Mermaid diagram was swallowed as literal text, and raw ``` backticks showed in the prose.

## Root cause

kramdown's fenced-code opener only recognizes a **single whitespace-free info token** (```` ```lang ````). A space makes the line **not a fence at all** — so ```` ```plain text ```` fell through as literal prose, its intended *closing* ` ``` ` became an *opener*, and fence parity inverted for the entire rest of each page. Reproduced against the exact GitHub-Pages kramdown + GFM engine.

## Fix

Replace all **11** ```` ```plain text ```` openers with ```` ```text ```` (valid single token, unstyled monospace — right for the ASCII tables/diagrams in these blocks) across 3 designs:

| File | Fences fixed |
|---|---|
| harmful-content-detection.md | 6 |
| system-design-payment-system.md | 4 |
| system-design-instagram.md | 1 |

Verified post-fix: every page renders with all code blocks + Mermaid diagrams intact and zero stray backticks.

## Recurrence prevention (separate, in `~/.hermes/scripts/`)

- `jekyll-normalize.py` (fix #15): opening-fence info strings with whitespace are now collapsed to a single valid token (plain-text family → `text`).
- `verify-post-thumbnails.py`: publish gate now hard-fails any multi-word fence info string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)