### PR TITLE
Split designs into System Design + Machine Learning nav tabs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ header_pages:
   - resume.md
   - portfolio.md
   - designs.md
+  - machine-learning.md
   - blog.md
   - index.md
 

--- a/_designs/harmful-content-detection.md
+++ b/_designs/harmful-content-detection.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "ML System Design: Harmful-Content Detection"
-category: system-design
+category: ml-system-design
 date: 2026-07-07
 tags: [System Design, ML, Content Moderation]
 description: "We're operating a social platform at Meta/Facebook scale — roughly 1 billion posts per day across text, images, and video, with harmful content making up less than 1% of that volume. At that scale even 0.1% means a million harmful posts daily. The product problem is simple: users who encounter vi..."

--- a/_includes/design-list.html
+++ b/_includes/design-list.html
@@ -1,0 +1,50 @@
+{%- comment %}
+  Renders one category's designs as the Portfolio-style rail + feed. Dedicated
+  single-category pages (System Design, Machine Learning) call this once; the page's
+  own H1 + intro supply the heading, so no per-category section header is emitted.
+  Params:
+    include.category — front-matter `category:` slug to filter on
+    include.prefix   — title prefix stripped from each card's display name
+    include.label    — small-caps label shown atop the sidebar rail
+{%- endcomment %}
+{%- assign designs = site.designs | where: "category", include.category | sort: "date" | reverse %}
+{%- if designs.size > 0 %}
+<div class="portfolio-layout">
+
+<aside class="portfolio-rail">
+  <div class="rail-group">
+    <div class="rail-title">{{ include.label }}</div>
+    <nav>
+      {%- for d in designs %}
+      {%- assign name = d.title | remove_first: include.prefix %}
+      <a href="#{{ d.title | slugify }}" data-spy><span class="nm">{{ name | escape }}</span></a>
+      {%- endfor %}
+    </nav>
+  </div>
+</aside>
+
+<div class="portfolio-feed">
+  {%- for d in designs %}
+  {%- assign name = d.title | remove_first: include.prefix %}
+  {%- assign seed = d.title | size | modulo: 6 %}
+  <article id="{{ d.title | slugify }}" class="portfolio-item">
+    {%- if d.thumbnail %}
+    <a class="thumb" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><img src="{{ d.thumbnail | relative_url }}?v={{ site.time | date: '%s' }}" alt="{{ name | escape }} architecture diagram" loading="lazy"></a>
+    {%- else %}
+    <a class="thumb placeholder g{{ seed }}" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><span>{{ name | escape }}</span></a>
+    {%- endif %}
+    <div class="body">
+      <h3><a href="{{ d.url | relative_url }}">{{ name | escape }}</a></h3>
+      <p>{{ d.description | default: d.excerpt | strip_html | truncatewords: 46 }}</p>
+      {%- if d.tags.size > 0 %}
+      <ul class="tags">{% for tag in d.tags %}<li>{{ tag | escape }}</li>{% endfor %}</ul>
+      {%- endif %}
+      <div class="links"><a class="gh" href="{{ d.url | relative_url }}">Read the design →</a>{% if d.mvp_repo %}<a class="gh" href="{{ d.mvp_repo }}" target="_blank" rel="noopener">GitHub MVP ↗</a>{% endif %}</div>
+    </div>
+  </article>
+  {%- endfor %}
+</div>
+</div>
+{%- else %}
+<p>No designs yet — first write-ups landing soon.</p>
+{%- endif %}

--- a/designs.md
+++ b/designs.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Designs
+title: System Design
 permalink: /designs/
 description: "System design write-ups by Ilia Zlobin — production-grade architectures with diagrams, data models, deep dives, and trade-offs."
 ---
@@ -15,68 +15,4 @@ description: "System design write-ups by Ilia Zlobin — production-grade archit
 
 <p class="portfolio-intro">System design write-ups — production-grade architectures, section for section: requirements, back-of-the-envelope estimates, data model, high-level design, and the deep dives. Diagrams and code throughout.</p>
 
-{%- comment %}
-  Designs are grouped into ordered categories. A design's `category:` front-matter
-  field selects its group; the arrays below define the group order, headings, and the
-  title prefix stripped for display. Empty groups are skipped, so a new category's
-  section appears automatically once its first design lands.
-{%- endcomment %}
-{%- assign cat_slugs    = "system-design,ml-system-design" | split: "," %}
-{%- assign cat_labels   = "System Design,ML System Design" | split: "," %}
-{%- assign cat_prefixes = "System Design: ,ML System Design: " | split: "," %}
-{%- assign designs = site.designs | sort: "date" | reverse %}
-{%- if designs.size > 0 %}
-<div class="portfolio-layout">
-
-<aside class="portfolio-rail">
-  {%- for slug in cat_slugs %}
-  {%- assign group = designs | where: "category", slug %}
-  {%- if group.size > 0 %}
-  {%- assign label = cat_labels[forloop.index0] %}
-  {%- assign prefix = cat_prefixes[forloop.index0] %}
-  <div class="rail-group">
-    <div class="rail-title">{{ label }}</div>
-    <nav>
-      {%- for d in group %}
-      {%- assign name = d.title | remove_first: prefix %}
-      <a href="#{{ d.title | slugify }}" data-spy><span class="nm">{{ name | escape }}</span></a>
-      {%- endfor %}
-    </nav>
-  </div>
-  {%- endif %}
-  {%- endfor %}
-</aside>
-
-<div class="portfolio-feed">
-  {%- for slug in cat_slugs %}
-  {%- assign group = designs | where: "category", slug %}
-  {%- if group.size > 0 %}
-  {%- assign label = cat_labels[forloop.index0] %}
-  {%- assign prefix = cat_prefixes[forloop.index0] %}
-  <h2 class="feed-section" id="cat-{{ slug }}">{{ label }}</h2>
-  {%- for d in group %}
-  {%- assign name = d.title | remove_first: prefix %}
-  {%- assign seed = d.title | size | modulo: 6 %}
-  <article id="{{ d.title | slugify }}" class="portfolio-item">
-    {%- if d.thumbnail %}
-    <a class="thumb" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><img src="{{ d.thumbnail | relative_url }}?v={{ site.time | date: '%s' }}" alt="{{ name | escape }} architecture diagram" loading="lazy"></a>
-    {%- else %}
-    <a class="thumb placeholder g{{ seed }}" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><span>{{ name | escape }}</span></a>
-    {%- endif %}
-    <div class="body">
-      <h3><a href="{{ d.url | relative_url }}">{{ name | escape }}</a></h3>
-      <p>{{ d.description | default: d.excerpt | strip_html | truncatewords: 46 }}</p>
-      {%- if d.tags.size > 0 %}
-      <ul class="tags">{% for tag in d.tags %}<li>{{ tag | escape }}</li>{% endfor %}</ul>
-      {%- endif %}
-      <div class="links"><a class="gh" href="{{ d.url | relative_url }}">Read the design →</a>{% if d.mvp_repo %}<a class="gh" href="{{ d.mvp_repo }}" target="_blank" rel="noopener">GitHub MVP ↗</a>{% endif %}</div>
-    </div>
-  </article>
-  {%- endfor %}
-  {%- endif %}
-  {%- endfor %}
-</div>
-</div>
-{%- else %}
-<p>No designs yet — first write-ups landing soon.</p>
-{%- endif %}
+{% include design-list.html category="system-design" prefix="System Design: " label="System Design" %}

--- a/machine-learning.md
+++ b/machine-learning.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Machine Learning
+permalink: /machine-learning/
+description: "Machine-learning system design write-ups by Ilia Zlobin — end-to-end ML architectures with data and feature pipelines, model and serving deep dives, evaluation, and trade-offs."
+---
+
+<link rel="stylesheet" href="{{ '/assets/css/portfolio.css' | relative_url }}?v={{ site.time | date: '%s' }}">
+<style>
+  /* Reuses the Portfolio layout; the card title is a link to the write-up, so keep it
+     reading as a heading (not default link-blue) and only tint on hover. */
+  .portfolio-item h3 a { color: inherit; text-decoration: none; }
+  .portfolio-item h3 a:hover { color: var(--accent); }
+</style>
+
+<p class="portfolio-intro">Machine-learning system design write-ups — end-to-end ML architectures, section for section: problem &amp; ML framing, data and features, model, training and serving, evaluation, and the deep dives. Diagrams and code throughout.</p>
+
+{% include design-list.html category="ml-system-design" prefix="ML System Design: " label="Machine Learning" %}


### PR DESCRIPTION
Renames the **Designs** tab to **System Design** and adds a dedicated **Machine Learning** tab, so ML write-ups live under their own section.

## Changes
- **`designs.md`** — title `Designs → System Design`; permalink unchanged (`/designs/`); renders only `category: system-design`.
- **`machine-learning.md`** — new page at `/machine-learning/`, renders `category: ml-system-design`.
- **`_config.yml`** — add `machine-learning.md` to `header_pages` (after `designs.md`).
- **`_designs/harmful-content-detection.md`** — retag `category: system-design → ml-system-design` (moves it to the ML tab).
- **`_includes/design-list.html`** — new shared include; factors out the rail+feed card markup, rendered per-category so each dedicated page skips the redundant in-column section heading.

## Verified against a local Jekyll build
- Nav: Resume · Portfolio · **System Design** · **Machine Learning** · Blog · About
- `/designs/` → H1 "System Design", 31 system-design cards, Harmful-Content no longer present
- `/machine-learning/` → H1 "Machine Learning", 1 card: "Harmful-Content Detection"
- No redundant in-column `feed-section` headers on either page

Future ML designs only need `category: ml-system-design` to appear on the Machine Learning tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)