### PR TITLE
fix(designs): restore 4 designs missing category: (Bot Detection + 3 infra)

### DIFF
--- a/_designs/bot-detection.md
+++ b/_designs/bot-detection.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "ML System Design: Bot Detection"
+category: ml-system-design
 date: 2026-07-08
 tags: [machine-learning, bot-detection, classification]
 description: "We run a social platform at 500M DAU — roughly 10 billion user actions per day across posts, follows, likes, messages, and friend requests."

--- a/_designs/system-design-doordash-uber-eats.md
+++ b/_designs/system-design-doordash-uber-eats.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "System Design: DoorDash / Uber Eats"
+category: system-design
 date: 2026-07-08
 tags: [System Design]
 description: "DoorDash and Uber Eats operate a three-sided marketplace: customers order food from restaurants and a driver picks it up and delivers it."

--- a/_designs/system-design-metrics-monitoring.md
+++ b/_designs/system-design-metrics-monitoring.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "System Design: Metrics Monitoring"
+category: system-design
 date: 2026-07-08
 tags: [System Design]
 description: "A metrics monitoring platform ingests time-series data from hundreds of thousands of services, stores it durably, and answers sub-second dashboard queries while evaluating alert rules against a streaming firehose."

--- a/_designs/system-design-video-conferencing-zoom.md
+++ b/_designs/system-design-video-conferencing-zoom.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "System Design: Video Conferencing (Zoom)"
+category: system-design
 date: 2026-07-07
 tags: [System Design]
 description: "Video conferencing connects hundreds of participants in a real-time audio/video session where every frame must travel from a speaker's camera to every listener's screen in under 150ms."


### PR DESCRIPTION
PR #112 merged Bot Detection but `/machine-learning/` still shows **"No designs yet"** — and the same bug silently dropped 3 recent infra designs off `/system-design/`.

**Root cause:** the nav pages render `site.designs | where: "category", <slug>`. A design with **no `category:` line** matches no group, so the page falls back to the empty-state message. Categories were retrofitted onto older designs in #108, but the publisher (`notion-to-jekyll.py build_post()`) never emitted the line, so every design generated since shipped category-less.

**Restored here (4 designs):**
- `bot-detection.md` → `category: ml-system-design` (was breaking `/machine-learning/`)
- `system-design-doordash-uber-eats.md` (#109) → `system-design`
- `system-design-metrics-monitoring.md` (#110) → `system-design`
- `system-design-video-conferencing-zoom.md` (#106) → `system-design`

**Generator gap fixed separately** in the Hermes config repo (`build_post()` now derives `category:` from the title prefix), so future designs land with the right category automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)