### PR TITLE
fix(designs): restore category: on Harmful-Content Detection (3rd ML design missing from site)

### DIFF
--- a/_designs/harmful-content-detection.md
+++ b/_designs/harmful-content-detection.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "ML System Design: Harmful-Content Detection"
+category: ml-system-design
 date: 2026-07-08
 tags: [System Design, Machine Learning, Content Moderation, Trust & Safety]
 description: "A deep dive into the ML system design for large-scale harmful content detection, covering the two-stage inference cascade, multi-modal cross-attention transformer, calibration layer, positive-suppression bias, and drift monitoring."


### PR DESCRIPTION
## Problem
The Content Tracker shows **3** ML System Designs published (Video Recommendations, Harmful-Content Detection, Bot Detection), but `/machine-learning/` on the site renders only **2** — Harmful-Content Detection is missing.

## Root cause
The re-publish (PR #115, `c414442`) wrote `_designs/harmful-content-detection.md` with **no `category:` front-matter line** — it was generated by a stale copy of `notion-to-jekyll.py` (the fixed host copy correctly derives `category` from the `ML System Design` title prefix). The Machine Learning nav page renders:

```liquid
{% include design-list.html category="ml-system-design" ... %}
```

i.e. `site.designs | where: "category", "ml-system-design"`. A design with no `category` matches **no** group and silently disappears.

## Fix
Add `category: ml-system-design` to the front matter, matching `video-recommendations.md` and `bot-detection.md`. One-line change; the design page content is unchanged.

After merge, GitHub Pages rebuilds `master` and the third card appears on `/machine-learning/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Jytawp9ssw99F7TQqeqsg