### PR TITLE
Add Research section to nav (/research/ tab)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ header_pages:
   - designs.md
   - machine-learning.md
   - infrastructure.md
+  - research.md
   - blog.md
   - index.md
 

--- a/research.md
+++ b/research.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Research
+permalink: /research/
+description: "AI/ML research write-ups by Ilia Zlobin — rigorous paper surveys and hands-on empirical studies: literature taxonomies and lineage maps, method deep dives with intuition-first math, and reproducible experiments with results and analysis."
+---
+
+<link rel="stylesheet" href="{{ '/assets/css/portfolio.css' | relative_url }}?v={{ site.time | date: '%s' }}">
+<style>
+  /* Reuses the Portfolio layout; the card title is a link to the write-up, so keep it
+     reading as a heading (not default link-blue) and only tint on hover. */
+  .portfolio-item h3 a { color: inherit; text-decoration: none; }
+  .portfolio-item h3 a:hover { color: var(--accent); }
+</style>
+
+<p class="portfolio-intro">Scientific AI/ML research — rigorous topic surveys (taxonomy, lineage, and method deep dives, intuition-first) alongside hands-on empirical studies that run the experiment and report the numbers. Papers, diagrams, and reproducible notebooks throughout.</p>
+
+{% include design-list.html category="research" prefix="Research: " label="Research" %}


### PR DESCRIPTION
## Research section

Adds a **Research** tab (`/research/`) for scientific AI/ML research write-ups — paper surveys and empirical studies — mirroring the existing System Design / Machine Learning / Infra sections.

- `research.md` — landing page rendering `design-list.html category="research"` (cloned from `infrastructure.md`)
- `_config.yml` — `research.md` added to `header_pages`, positioned after Infra

The tab shows the empty *"No designs yet — first write-ups landing soon"* state until the first Research row is published via content-hub. (The Notion→Jekyll `category: research` routing is wired separately in the hermes-config repo.)

Verified with a local `jekyll build`: `/research/index.html` renders, the nav link is present, and the empty-state message shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EivdGG7er1SGVENBBUqRjH
