### PR TITLE
Shorten mobile nav labels (Design/ML) + tighten spacing

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,31 @@
+<header class="site-header" role="banner">
+
+  <div class="wrapper">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    {%- if page_paths -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          {%- for path in page_paths -%}
+            {%- assign my_page = site.pages | where: "path", path | first -%}
+            {%- if my_page.title -%}
+            {%- comment -%}Nav shows a short `nav_title` when set (e.g. "Design", "ML"); the page keeps its full `title` for the H1 + SEO.{%- endcomment -%}
+            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.nav_title | default: my_page.title | escape }}</a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>
+</header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
 
     {%- if page_paths -%}
-      <nav class="site-nav">
+      <nav class="site-nav" aria-label="Primary">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />
         <label for="nav-trigger">
           <span class="menu-icon">

--- a/assets/navbar-always-visible.css
+++ b/assets/navbar-always-visible.css
@@ -19,7 +19,7 @@
   }
   .site-nav .page-link {
     display: inline-block !important;
-    padding: 0 !important;
+    padding: 4px 0 !important;
     margin-left: 0 !important;
     margin-right: 16px !important;
     line-height: 2.1 !important;   /* breathing room between wrapped rows */

--- a/assets/navbar-always-visible.css
+++ b/assets/navbar-always-visible.css
@@ -19,8 +19,11 @@
   }
   .site-nav .page-link {
     display: inline-block !important;
-    padding: 0 10px !important;
+    padding: 0 !important;
     margin-left: 0 !important;
-    margin-right: 20px !important;
+    margin-right: 16px !important;
+    line-height: 2.1 !important;   /* breathing room between wrapped rows */
+    font-size: 0.95rem !important; /* a touch smaller so more fit per row */
   }
+  .site-nav .page-link:last-child { margin-right: 0 !important; }
 }

--- a/designs.md
+++ b/designs.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: System Design
+nav_title: Design
 permalink: /designs/
 description: "System design write-ups by Ilia Zlobin — production-grade architectures with diagrams, data models, deep dives, and trade-offs."
 ---

--- a/machine-learning.md
+++ b/machine-learning.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Machine Learning
+nav_title: ML
 permalink: /machine-learning/
 description: "Machine-learning system design write-ups by Ilia Zlobin — end-to-end ML architectures with data and feature pipelines, model and serving deep dives, evaluation, and trade-offs."
 ---


### PR DESCRIPTION
## Shorter mobile nav

Adding the Research tab pushed the mobile nav to 3 wrapped rows (8 items). This shortens the two longest labels and tightens spacing so it packs to ~2 rows, keeping every link visible (no hamburger).

- New `_includes/header.html` (overrides the minima gem) renders `nav_title | default: title` — so a nav label can differ from the page `<h1>`.
- `designs.md` → `nav_title: Design` (page `<h1>` stays **System Design**)
- `machine-learning.md` → `nav_title: ML` (page `<h1>` stays **Machine Learning**)
- `navbar-always-visible.css` → 16px gaps, 0.95rem, last-child margin trim

Desktop is unchanged (one row). Built locally and confirmed: nav renders **Design / ML** while both landing-page `<h1>`s remain full.

> Note: the local preview couldn't render the `<600px` breakpoint, so the mobile row count is math-verified rather than screenshotted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EivdGG7er1SGVENBBUqRjH
