### PR TITLE
Shorten Portfolio nav label to "Work"

### DIFF
--- a/portfolio.md
+++ b/portfolio.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Portfolio
+nav_title: Work
 permalink: /portfolio/
 description: "Selected work by Ilia Zlobin across AI/agentic systems, cloud platform engineering, and applied ML — each with source code, architecture diagrams, and walkthrough videos."
 ---


### PR DESCRIPTION
## Nav: Portfolio → Work

Follow-up to #129. Shortens the widest remaining nav label so the mobile nav packs tighter (toward one row), reusing the `nav_title` override from #129 — the `/portfolio/` page keeps its full **Portfolio** `<h1>` + SEO title.

Built + verified: nav = Resume · Work · Design · ML · Infra · Research · Blog · About; `/portfolio/` `<h1>` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EivdGG7er1SGVENBBUqRjH
