### PR TITLE
Restore Portfolio nav label (revert "Work")

### DIFF
--- a/portfolio.md
+++ b/portfolio.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Portfolio
-nav_title: Work
 permalink: /portfolio/
 description: "Selected work by Ilia Zlobin across AI/agentic systems, cloud platform engineering, and applied ML — each with source code, architecture diagrams, and walkthrough videos."
 ---


### PR DESCRIPTION
## Nav: restore "Portfolio"

Owner preference — revert the "Work" label (#130) back to **Portfolio**; the 2-row mobile nav is fine as-is. Removes the `nav_title` override from `portfolio.md`. The Design/ML abbreviations (#129) stay.

Built + verified: nav = Resume · Portfolio · Design · ML · Infra · Research · Blog · About.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EivdGG7er1SGVENBBUqRjH
