### PR TITLE
tech: publish Tech: RabbitMQ deep-dive

### DIFF
--- a/_designs/tech-rabbitmq.md
+++ b/_designs/tech-rabbitmq.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: "Tech: RabbitMQ"
+category: tech
+date: 2026-07-14
+tags: [System Design]
+description: ""
+thumbnail: /images/posts/tech-rabbitmq.svg
+---
+
+<!--more-->

--- a/images/posts/tech-rabbitmq.svg
+++ b/images/posts/tech-rabbitmq.svg
@@ -1,0 +1,16 @@
+<!-- hermes-cover-card: local fallback (no diagram rendered). A post WITH a Mermaid
+     diagram must NOT use this — render the real diagram instead (verify-post-thumbnails.py enforces). -->
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="800" viewBox="0 0 600 800" role="img" aria-label="Tech: RabbitMQ">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f766e"/>
+      <stop offset="1" stop-color="#14b8a6"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" fill="url(#bg)"/>
+  <rect x="70" y="95" width="120" height="70" rx="12" fill="#ffffff" opacity="0.10"/><rect x="240" y="95" width="120" height="70" rx="12" fill="#ffffff" opacity="0.10"/><rect x="410" y="95" width="120" height="70" rx="12" fill="#ffffff" opacity="0.10"/><rect x="150" y="215" width="120" height="70" rx="12" fill="#ffffff" opacity="0.10"/><rect x="330" y="215" width="120" height="70" rx="12" fill="#ffffff" opacity="0.10"/>
+  <g stroke="#ffffff" stroke-width="2.5" opacity="0.16" fill="none"><path d="M130 165 L210 215"/><path d="M300 165 L210 215"/><path d="M300 165 L390 215"/><path d="M470 165 L390 215"/></g>
+  <text x="300" y="368" text-anchor="middle" font-family="Inter, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#ffffff" opacity="0.92">SYSTEM DESIGN</text>
+  <text text-anchor="middle" font-family="Inter, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-size="54" font-weight="800" fill="#ffffff"><tspan x="300" y="452">Tech: RabbitMQ</tspan></text>
+  <text x="300" y="760" text-anchor="middle" font-family="Inter, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#ffffff" opacity="0.78">iliazlobin.com</text>
+</svg>


### PR DESCRIPTION
Auto-published from the Notion Tech row by the deterministic tech-publish host cron. `category: tech` -> lists on /tech/, page at /designs/tech-rabbitmq/. Built + verify-post-thumbnails gate PASSED on the host before this PR.