### PR TITLE
Tech pages: tag search across categories + real tags + readable diagrams

### DIFF
--- a/_designs/tech-elasticsearch.md
+++ b/_designs/tech-elasticsearch.md
@@ -3,7 +3,7 @@ layout: post
 title: "Tech: Elasticsearch"
 category: tech
 date: 2026-07-15
-tags: [System Design]
+tags: [Deep-Dive, Search, Databases]
 description: "Elasticsearch is a distributed search and analytics engine built on Apache Lucene. You send JSON documents to a REST API, and within one second they become searchable across any field with ranking, aggregations, and geospatial queries."
 thumbnail: /images/posts/tech-elasticsearch.svg
 ---
@@ -43,7 +43,7 @@ Elasticsearch is a distributed search and analytics engine built on Apache Lucen
 
 **Segment merge.** Small segments accumulate over time and degrade search speed (more files to open). A background tiered merge policy (Lucene 4+) combines segments into larger ones, preferring to merge segments of similar size. Force-merge read-only indices to 1 segment for best search performance; never force-merge actively writing indices.
 
-**Scatter-gather search.** A search query hits the coordinating node, which parses the DSL into a Lucene query, looks up the routing table, and fans out to every shard (primary or replica) in parallel. Each shard runs the query phase (collect matching docIDs, score by BM25), then the fetch phase (retrieve `_source` for the top N hits). The coordinating node merges partial results, applies global scoring, sorts, paginates, and returns the response.
+**The write path.** Indexing a document is a replicated, write-ahead-logged operation. The coordinating node routes the doc to its primary shard by `hash(_id)`; the primary indexes it into an in-memory Lucene buffer and appends the raw operation to the `translog` before forwarding to the replicas. Only once every active replica has fsynced its translog does the primary acknowledge — so an accepted write survives a crash even before it becomes a searchable segment. The sequence below traces one `POST /index/_doc`, including the periodic refresh, flush, and merge that turn buffered writes into durable segments.
 
 ```mermaid
 sequenceDiagram
@@ -71,6 +71,8 @@ sequenceDiagram
     Note over Primary,Disk: Background merge: tiered merge policy
 ```
 
+**Scatter-gather search.** A search query hits the coordinating node, which parses the DSL into a Lucene query, looks up the routing table, and fans out to every shard (primary or replica) in parallel. Each shard runs the query phase (collect matching docIDs, score by BM25), then the fetch phase (retrieve `_source` for the top N hits). The coordinating node merges partial results, applies global scoring, sorts, paginates, and returns the response.
+
 ```mermaid
 flowchart TD
     Client([Client]) -->|Search query| CN[Coordinating Node]
@@ -81,8 +83,12 @@ flowchart TD
     Fetch --> CN
     CN --> Result([Response to client])
 
-    classDef node fill:#1A1A1A,stroke:#444,color:#fff
-    class Client,CN,Shard,Lucene,Score,Fetch,Result node
+    classDef client fill:#fff3bf,stroke:#f08c00,color:#1a1a1a;
+    classDef svc fill:#d0ebff,stroke:#1c7ed6,color:#1a1a1a;
+    classDef engine fill:#d3f9d8,stroke:#2f9e44,color:#1a1a1a;
+    class Client,Result client;
+    class CN svc;
+    class Shard,Lucene,Score,Fetch engine;
 ```
 
 ### What you build with it

--- a/_designs/tech-postgresql.md
+++ b/_designs/tech-postgresql.md
@@ -3,7 +3,7 @@ layout: post
 title: "Tech: PostgreSQL"
 category: tech
 date: 2026-07-15
-tags: [System Design]
+tags: [Deep-Dive, Databases, PostgreSQL]
 description: "PostgreSQL is a single-node relational database that wins on correctness, extensibility, and community trust."
 thumbnail: /images/posts/tech-postgresql.svg
 ---

--- a/_designs/tech-redis.md
+++ b/_designs/tech-redis.md
@@ -3,7 +3,7 @@ layout: post
 title: "Tech: Redis"
 category: tech
 date: 2026-07-15
-tags: [System Design]
+tags: [Deep-Dive, Databases, Caching]
 description: "Redis is an in-memory key-value store where every command runs on a single thread and the entire server is a hash table of keys mapped to data structures. There is no query optimizer, no transaction manager, no buffer pool. A command is a direct function call against the structure in memory."
 thumbnail: /images/posts/tech-redis.svg
 ---
@@ -168,9 +168,9 @@ Redis has four deployment modes with different failure profiles.
 
 ```mermaid
 flowchart LR
-    classDef box fill:#2A2A3A,stroke:#446,color:#D0D0F0
-    classDef choice fill:#2A2A2A,stroke:#555,color:#F0F0F0
-    classDef bad fill:#3A2222,stroke:#644,color:#F0B0B0
+    classDef box fill:#d0ebff,stroke:#1c7ed6,color:#1a1a1a
+    classDef choice fill:#d0ebff,stroke:#1c7ed6,color:#1a1a1a
+    classDef bad fill:#d0ebff,stroke:#1c7ed6,color:#1a1a1a
 
     START([Start]):::choice --> Q{Scale + HA?}:::choice
     Q -->|Dev only| S[Standalone<br/>one process]:::box

--- a/_includes/design-list.html
+++ b/_includes/design-list.html
@@ -1,14 +1,40 @@
 {%- comment %}
-  Renders one category's designs as the Portfolio-style rail + feed. Dedicated
-  single-category pages (System Design, Machine Learning) call this once; the page's
-  own H1 + intro supply the heading, so no per-category section header is emitted.
+  Renders one category's designs as the Portfolio-style rail + feed, with a tag filter.
+  Dedicated single-category pages (System Design, Machine Learning, Infra, Tech, Research)
+  call this once; the page's own H1 + intro supply the heading.
   Params:
-    include.category — front-matter `category:` slug to filter on
-    include.prefix   — title prefix stripped from each card's display name
-    include.label    — small-caps label shown atop the sidebar rail
+    include.category    — front-matter `category:` slug to filter on
+    include.prefix      — title prefix stripped from each card's display name
+    include.label       — small-caps label shown atop the sidebar rail
+    include.count_noun  — singular noun for the result counter (default "write-up")
+    include.empty_text  — shown when the category has no designs yet
+  The tag filter reuses the blog's setupBlogFilter() (assets/js/site.js) — same
+  data-blog-filter / data-blog-feed / data-blog-tags contract, layout-agnostic.
 {%- endcomment %}
 {%- assign designs = site.designs | where: "category", include.category | sort: "date" | reverse %}
 {%- if designs.size > 0 %}
+
+{%- comment %} Tag universe for THIS category (name + count) — powers the filter box + suggestions. {%- endcomment %}
+{%- assign all_tags = "" | split: "" %}
+{%- for d in designs %}{%- assign all_tags = all_tags | concat: d.tags %}{%- endfor %}
+{%- assign uniq_tags = all_tags | uniq | sort %}
+
+{%- if uniq_tags.size > 0 %}
+<div class="blog-controls" data-blog-filter data-count-noun="{{ include.count_noun | default: 'write-up' }}">
+  <div class="tag-input" data-tag-input>
+    <svg class="ti-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>
+    <span class="ti-tokens"></span>
+    <input type="text" class="ti-field" placeholder="Filter by tag…" aria-label="Filter {{ include.label }} write-ups by tag" autocomplete="off" spellcheck="false">
+    <div class="ti-suggest" hidden role="listbox" aria-label="Tag suggestions"></div>
+  </div>
+  <div class="bc-right">
+    <span class="result-count" data-result-count></span>
+    <button class="ti-clear" data-tag-clear type="button" hidden>Clear all</button>
+  </div>
+</div>
+<script type="application/json" data-blog-tags>[{%- for t in uniq_tags %}{%- assign m = all_tags | where_exp: "x", "x == t" %}{"name": {{ t | jsonify | replace: '</', '<\/' }}, "count": {{ m.size }}}{%- unless forloop.last %},{% endunless %}{%- endfor %}]</script>
+{%- endif %}
+
 <div class="portfolio-layout">
 
 <aside class="portfolio-rail">
@@ -17,17 +43,17 @@
     <nav>
       {%- for d in designs %}
       {%- assign name = d.title | remove_first: include.prefix %}
-      <a href="#{{ d.title | slugify }}" data-spy><span class="nm">{{ name | escape }}</span></a>
+      <a href="#{{ d.title | slugify }}" data-spy data-tags="{{ d.tags | join: '|' | escape }}"><span class="nm">{{ name | escape }}</span></a>
       {%- endfor %}
     </nav>
   </div>
 </aside>
 
-<div class="portfolio-feed">
+<div class="portfolio-feed" data-blog-feed>
   {%- for d in designs %}
   {%- assign name = d.title | remove_first: include.prefix %}
   {%- assign seed = d.title | size | modulo: 6 %}
-  <article id="{{ d.title | slugify }}" class="portfolio-item">
+  <article id="{{ d.title | slugify }}" class="portfolio-item" data-tags="{{ d.tags | join: '|' | escape }}">
     {%- if d.thumbnail %}
     <a class="thumb" href="{{ d.url | relative_url }}" aria-label="{{ name | escape }} — read the design"><img src="{{ d.thumbnail | relative_url }}?v={{ site.time | date: '%s' }}" alt="{{ name | escape }} architecture diagram" loading="lazy"></a>
     {%- else %}
@@ -37,7 +63,7 @@
       <h3><a href="{{ d.url | relative_url }}">{{ name | escape }}</a></h3>
       <p>{{ d.description | default: d.excerpt | strip_html | truncatewords: 46 }}</p>
       {%- if d.tags.size > 0 %}
-      <ul class="tags">{% for tag in d.tags %}<li>{{ tag | escape }}</li>{% endfor %}</ul>
+      <div class="pc-tags">{%- for tag in d.tags %}<a class="tag" data-tag="{{ tag | escape }}" href="?tag={{ tag | url_encode }}">{{ tag | escape }}</a>{%- endfor %}</div>
       {%- endif %}
       <div class="links"><a class="gh" href="{{ d.url | relative_url }}">Read the design →</a>{% if d.mvp_repo %}<a class="gh" href="{{ d.mvp_repo }}" target="_blank" rel="noopener">GitHub MVP ↗</a>{% endif %}</div>
     </div>
@@ -45,6 +71,8 @@
   {%- endfor %}
 </div>
 </div>
+
+<p class="no-results" hidden>No {{ include.label | downcase }} write-ups match that filter. <button class="link-btn" data-filter-clear type="button">Clear filter</button></p>
 {%- else %}
 <p>{{ include.empty_text | default: "No designs yet — first write-ups landing soon." }}</p>
 {%- endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,8 +12,17 @@ layout: default
       </time>
       <span class="reading-time">{{ minutes }} min read</span>
       {%- if page.tags and page.tags.size > 0 %}
+      {%- comment %} A design's tags route to ITS OWN category page (with ?tag= filter), not the blog. {%- endcomment %}
+      {%- case page.category %}
+        {%- when 'tech' %}{%- assign tag_base = '/tech/' %}
+        {%- when 'infra' %}{%- assign tag_base = '/infrastructure/' %}
+        {%- when 'system-design-ml' %}{%- assign tag_base = '/machine-learning/' %}
+        {%- when 'research' %}{%- assign tag_base = '/research/' %}
+        {%- when 'system-design' %}{%- assign tag_base = '/designs/' %}
+        {%- else %}{%- assign tag_base = '/blog/' %}
+      {%- endcase %}
       <span class="post-tags">
-        {%- for tag in page.tags %}<a class="tag" href="{{ '/blog/' | relative_url }}?tag={{ tag | url_encode }}">{{ tag }}</a>{% endfor -%}
+        {%- for tag in page.tags %}<a class="tag" href="{{ tag_base | relative_url }}?tag={{ tag | url_encode }}">{{ tag }}</a>{% endfor -%}
       </span>
       {%- endif %}
     </div>

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -104,3 +104,66 @@
   .portfolio-item { grid-template-columns: 1fr; }
   .portfolio-item .thumb { aspect-ratio: 16 / 9; border-right: 0; border-bottom: 1px solid var(--line); min-height: 0; }
 }
+
+/* ==========================================================================
+   Tag filter — ported from blog.css so the design/ML/infra/tech/research
+   category pages share the blog's setupBlogFilter() UI (same class contract).
+   ========================================================================== */
+.blog-controls {
+  position: sticky; top: 0; z-index: 30; background: var(--bg);
+  padding: .8rem 0 .8rem; margin-bottom: 1.2rem; border-bottom: 1px solid var(--line);
+  display: flex; flex-wrap: wrap; gap: .6rem 1rem; align-items: center; justify-content: space-between;
+}
+.tag-input {
+  position: relative; flex: 1 1 340px; max-width: 560px; display: flex; align-items: center; flex-wrap: wrap; gap: .4rem;
+  background: #fff; border: 1px solid var(--line); border-radius: 10px; padding: .4rem .6rem; cursor: text;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+.tag-input:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.ti-icon { width: 16px; height: 16px; color: var(--ink-faint); flex: 0 0 auto; }
+.ti-tokens { display: contents; }
+.ti-token {
+  display: inline-flex; align-items: center; gap: .3rem; font-size: .8rem; font-weight: 600;
+  background: var(--accent); color: #fff; border-radius: 999px; padding: .18rem .3rem .18rem .6rem; animation: tokenIn .18s ease;
+}
+.ti-token button { background: rgba(255,255,255,.25); color: #fff; border: 0; border-radius: 50%; width: 16px; height: 16px; line-height: 1; cursor: pointer; font-size: .82rem; display: flex; align-items: center; justify-content: center; padding: 0; }
+.ti-token button:hover { background: rgba(255,255,255,.5); }
+@keyframes tokenIn { from { opacity: 0; transform: scale(.8); } to { opacity: 1; transform: none; } }
+.ti-field { flex: 1 1 120px; min-width: 100px; border: 0; outline: 0; background: none; font-family: inherit; font-size: .92rem; color: var(--ink); padding: .2rem; }
+.ti-field::placeholder { color: var(--ink-faint); }
+.ti-suggest {
+  position: absolute; top: calc(100% + 6px); left: 0; right: 0; z-index: 40; max-height: 264px; overflow-y: auto;
+  background: #fff; border: 1px solid var(--line); border-radius: 10px; box-shadow: var(--shadow-lg); padding: .35rem;
+}
+.ti-opt {
+  display: flex; align-items: center; justify-content: space-between; gap: .5rem; width: 100%;
+  font-family: inherit; font-size: .88rem; text-align: left; color: var(--ink-soft); background: none; border: 0;
+  border-radius: 7px; padding: .45rem .6rem; cursor: pointer;
+}
+.ti-opt:hover, .ti-opt.active { background: var(--accent-soft); color: var(--accent); }
+.ti-opt strong { color: var(--accent); font-weight: 800; }
+.ti-opt .ti-c { font-size: .72rem; font-weight: 700; color: var(--ink-faint); }
+.bc-right { display: flex; align-items: center; gap: .7rem; }
+.result-count { font-size: .82rem; color: var(--ink-faint); font-weight: 600; white-space: nowrap; }
+.ti-clear {
+  font-family: inherit; font-size: .82rem; font-weight: 600; color: var(--ink-soft);
+  background: #fff; border: 1px solid var(--line); border-radius: 999px; padding: .3rem .75rem; cursor: pointer;
+  transition: all .15s ease; white-space: nowrap;
+}
+.ti-clear:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Clickable tag chips on the design cards (replace the old static .tags list) */
+.pc-tags { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .8rem; }
+.pc-tags .tag {
+  font-size: .73rem; font-weight: 600; color: var(--ink-soft); text-decoration: none; cursor: pointer;
+  background: var(--accent-soft); border: 1px solid #dbe4ff; padding: .14rem .55rem; border-radius: 999px;
+  transition: all .12s ease;
+}
+.pc-tags .tag:hover { color: #fff; background: var(--accent); border-color: var(--accent); text-decoration: none; }
+
+/* Fade a filtered-out card out (mirrors blog.css .tl-item.is-filtered) */
+.portfolio-item.is-filtered { opacity: 0; transform: translateY(-8px) scale(.98); pointer-events: none; transition: opacity .22s ease, transform .22s ease; }
+
+.no-results { color: var(--ink-faint); padding: 1.5rem 0; }
+.link-btn { font-family: inherit; background: none; border: 0; color: var(--accent); font-weight: 600; cursor: pointer; padding: 0; }
+.link-btn:hover { text-decoration: underline; }

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -170,8 +170,13 @@
     var suggest = box.querySelector(".ti-suggest");
     var countEl = root.querySelector("[data-result-count]");
     var clearBtn = root.querySelector("[data-tag-clear]");
-    var cards = Array.prototype.slice.call(feed.querySelectorAll(".tl-item"));
+    // Works for BOTH layouts: the blog timeline (.tl-item) and the design/category
+    // pages (.portfolio-item). Design pages have no year dividers (the loop no-ops) and a
+    // sticky rail whose entries must hide alongside their filtered-out cards.
+    var cards = Array.prototype.slice.call(feed.querySelectorAll(".tl-item, .portfolio-item"));
     var dividers = Array.prototype.slice.call(feed.querySelectorAll(".year-divider"));
+    var railLinks = Array.prototype.slice.call(document.querySelectorAll(".portfolio-rail a[data-tags]"));
+    var noun = root.getAttribute("data-count-noun") || "post";
     var noRes = document.querySelector(".no-results");
 
     var allTags = [];
@@ -222,8 +227,9 @@
         }
         d.style.display = has ? "" : "none";
       });
+      railLinks.forEach(function (a) { a.style.display = matches(a) ? "" : "none"; });
       if (noRes) noRes.hidden = visible > 0;
-      if (countEl) countEl.textContent = visible + (visible === 1 ? " post" : " posts");
+      if (countEl) countEl.textContent = visible + " " + noun + (visible === 1 ? "" : "s");
       if (clearBtn) clearBtn.hidden = selected.length === 0;
       var url = new URL(window.location);
       if (selected.length) url.searchParams.set("tag", selected.join(",")); else url.searchParams.delete("tag");
@@ -307,7 +313,7 @@
     });
 
     // in-card tag chips add to the filter instead of navigating away
-    Array.prototype.slice.call(feed.querySelectorAll(".pc-tags .tag")).forEach(function (a) {
+    Array.prototype.slice.call(feed.querySelectorAll(".tag[data-tag]")).forEach(function (a) {
       a.addEventListener("click", function (e) {
         e.preventDefault();
         addTag(a.getAttribute("data-tag"));
@@ -315,7 +321,7 @@
       });
     });
 
-    if (countEl) countEl.textContent = cards.length + (cards.length === 1 ? " post" : " posts");
+    if (countEl) countEl.textContent = cards.length + " " + noun + (cards.length === 1 ? "" : "s");
 
     // initial selection from ?tag=a,b (e.g. arriving from a single post's tag link)
     var initial = new URL(window.location).searchParams.get("tag");


### PR DESCRIPTION
Addresses the review of the Tech write-ups:
- **Tag search on every category page** (design/ML/infra/tech/research) — reuses the blog's tag-filter UI. A design's tag chips now route to its own category page (`/tech/?tag=…`), not the blog.
- **Real topic tags** from each Notion row (Search, Databases, Caching…) instead of the old `System Design` default.
- **Readable diagrams**: Elasticsearch's black `#1A1A1A` flowchart → light semantic palette; the invalid `classDef` inside its sequenceDiagram removed; a write-path intro added and the search prose relocated so each diagram has its own description. Pipeline hardened so future dark diagrams are auto-lightened.