### PR TITLE
designs: sync all 41 page tags from Notion

### DIFF
--- a/_designs/autocomplete-query-suggestion.md
+++ b/_designs/autocomplete-query-suggestion.md
@@ -3,7 +3,7 @@ layout: post
 title: "ML System Design: Autocomplete / Query Suggestion"
 category: system-design-ml
 date: 2026-07-09
-tags: [System Design]
+tags: [Machine-Learning, Retrieval, Search, NLP]
 description: "A search engine handling 40K+ queries per second presents query suggestions as the user types, character by character. Each keystroke opens a sub-100 ms window: the suggestions must land before the next character arrives, or they are useless."
 thumbnail: /images/posts/autocomplete-query-suggestion.svg
 ---

--- a/_designs/bot-detection.md
+++ b/_designs/bot-detection.md
@@ -3,7 +3,7 @@ layout: post
 title: "ML System Design: Bot Detection"
 category: system-design-ml
 date: 2026-07-08
-tags: [machine-learning, bot-detection, classification]
+tags: [Machine-Learning, Bot-Detection, Classification]
 description: "We run a social platform at 500M DAU — roughly 10 billion user actions per day across posts, follows, likes, messages, and friend requests."
 thumbnail: /images/posts/bot-detection.svg
 ---

--- a/_designs/harmful-content-detection.md
+++ b/_designs/harmful-content-detection.md
@@ -3,7 +3,7 @@ layout: post
 title: "ML System Design: Harmful-Content Detection"
 category: system-design-ml
 date: 2026-07-08
-tags: [System Design]
+tags: [Machine-Learning, Classification, Content-Moderation]
 description: "We're operating a social platform at Meta/Facebook scale — roughly 1 billion posts per day across text, images, and video, with harmful content making up less than 1% of that volume. At that scale even 0.1% means a million harmful posts daily."
 thumbnail: /images/posts/harmful-content-detection.svg
 ---

--- a/_designs/news-feed-ranking.md
+++ b/_designs/news-feed-ranking.md
@@ -3,7 +3,7 @@ layout: post
 title: "ML System Design: News Feed Ranking"
 category: system-design-ml
 date: 2026-07-09
-tags: [System Design]
+tags: [Machine-Learning, Ranking, Recommendation, Personalization]
 description: "A social platform with hundreds of millions of daily active users needs to rank a firehose of content — posts, videos, articles, shares from followed accounts plus discovery content from the broader network — into a personalized feed that maximizes engagement."
 thumbnail: /images/posts/news-feed-ranking.svg
 ---

--- a/_designs/online-auction.md
+++ b/_designs/online-auction.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Online Auction"
 category: system-design
 date: 2026-07-01
-tags: [System Design]
+tags: [Real-Time, Distributed-Systems, Event-Driven, Interview-Prep]
 description: "An online auction platform lets sellers list items with a starting price and end time, and buyers compete by placing ascending bids. The winner is the highest bidder at close."
 thumbnail: /images/posts/2026-07-01-online-auction.svg
 redirect_from:

--- a/_designs/product-recommendations.md
+++ b/_designs/product-recommendations.md
@@ -3,7 +3,7 @@ layout: post
 title: "ML System Design: Product Recommendations"
 category: system-design-ml
 date: 2026-07-09
-tags: [System Design]
+tags: [Recommendation, Machine-Learning, Personalization, Ranking]
 description: "An e-commerce platform with 100M+ products and tens of millions of daily active users needs to show each visitor a personalized list of products they are most likely to purchase."
 thumbnail: /images/posts/product-recommendations.svg
 ---

--- a/_designs/system-design-ad-click-aggregator.md
+++ b/_designs/system-design-ad-click-aggregator.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Ad Click Aggregator"
 category: system-design
 date: 2026-07-01
-tags: [System Design]
+tags: [Stream-Processing, Ad-Tech, Aggregation, Kafka, Flink, Fraud-Detection]
 description: "An ad platform processes clicks from millions of users across thousands of publisher sites."
 thumbnail: /images/posts/2026-07-01-system-design-ad-click-aggregator.svg
 mvp_repo: https://github.com/iliazlobin/sd-ad-click-aggregator-backend-mvp

--- a/_designs/system-design-bitly.md
+++ b/_designs/system-design-bitly.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Bitly"
 category: system-design
 date: 2026-06-29
-tags: [System Design]
+tags: [Interview-Prep, Distributed-Systems, URL-Shortener]
 description: "Bitly turns long URLs into short ones and tracks every click. It looks simple — take a URL, generate a 7-character code, store the mapping, redirect on lookup. But the real challenge is analytics: every redirect must record an event without slowing the redirect."
 thumbnail: /images/posts/2026-06-29-system-design-bitly.svg
 redirect_from:

--- a/_designs/system-design-camelcamelcamel.md
+++ b/_designs/system-design-camelcamelcamel.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: CamelCamelCamel"
 category: system-design
 date: 2026-07-01
-tags: [System Design]
+tags: [Interview-Prep, Distributed-Systems, Event-Driven, Re-Design]
 description: "Design a price tracking service that lets users monitor product prices across online retailers, view historical price charts, and receive alerts when prices drop to a target threshold."
 thumbnail: /images/posts/2026-07-01-system-design-camelcamelcamel.svg
 redirect_from:

--- a/_designs/system-design-distributed-cache.md
+++ b/_designs/system-design-distributed-cache.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Distributed Cache"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Caching, Distributed-Systems, Redis, Consistent-Hashing]
 description: "A single-node cache (one Redis instance, one Memcached process) hits a hard wall: the server's RAM ceiling."
 thumbnail: /images/posts/system-design-distributed-cache.svg
 redirect_from:

--- a/_designs/system-design-doordash-uber-eats.md
+++ b/_designs/system-design-doordash-uber-eats.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: DoorDash / Uber Eats"
 category: system-design
 date: 2026-07-08
-tags: [System Design]
+tags: [Distributed-Systems, Geospatial, Real-Time, Event-Driven, Recommendation, Kafka, Food-Delivery]
 description: "DoorDash and Uber Eats operate a three-sided marketplace: customers order food from restaurants and a driver picks it up and delivers it."
 thumbnail: /images/posts/system-design-doordash-uber-eats.svg
 ---

--- a/_designs/system-design-dropbox.md
+++ b/_designs/system-design-dropbox.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Dropbox"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Distributed-Systems, Caching, Event-Driven]
 description: "Dropbox is a cloud file storage and sync service serving 700M+ registered users with exabytes of stored content. Users upload files from any device, access them everywhere, share folders with collaborators, and recover previous versions."
 thumbnail: /images/posts/2026-07-02-system-design-dropbox.svg
 redirect_from:

--- a/_designs/system-design-google-docs.md
+++ b/_designs/system-design-google-docs.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Google Docs"
 category: system-design
 date: 2026-07-01
-tags: [System Design]
+tags: [Real-Time, Distributed-Systems, Interview-Prep]
 description: "Google Docs serves ~2B monthly active users editing documents collaboratively in real time. A document open for editing draws 1–100 concurrent collaborators whose keystrokes must resolve to a single consistent document state with sub-200ms latency."
 thumbnail: /images/posts/2026-07-01-system-design-google-docs.svg
 mvp_repo: https://github.com/iliazlobin/sd-google-docs-backend-mvp

--- a/_designs/system-design-google-news.md
+++ b/_designs/system-design-google-news.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Google News"
 category: system-design
 date: 2026-06-29
-tags: [System Design]
+tags: [News-Aggregation, Real-Time, Event-Driven, Ranking]
 description: "Google News aggregates articles from 50,000+ publishers worldwide, groups coverage of the same event into story clusters, and serves a ranked, personalized feed to over 150 million monthly users across 70+ regional editions in 30+ languages."
 thumbnail: /images/posts/2026-06-29-system-design-google-news.svg
 redirect_from:

--- a/_designs/system-design-instagram.md
+++ b/_designs/system-design-instagram.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Instagram"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Social-Media, Read-Heavy, Media, Interview-Prep]
 description: "Instagram is a photo and video sharing platform where users post media, follow others, and scroll through a personalized feed."
 thumbnail: /images/posts/2026-07-02-system-design-instagram.svg
 redirect_from:

--- a/_designs/system-design-job-scheduler.md
+++ b/_designs/system-design-job-scheduler.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Job Scheduler"
 category: system-design
 date: 2026-06-29
-tags: [System Design]
+tags: [Distributed-Systems, Interview-Prep, Scheduling]
 description: "A job scheduler accepts one-shot and scheduled job submissions, executes them at the specified time, retries on failure, and surfaces execution history. Users submit, cancel, and monitor jobs through an API with no infrastructure management."
 thumbnail: /images/posts/2026-06-29-system-design-job-scheduler.svg
 redirect_from:

--- a/_designs/system-design-leetcode.md
+++ b/_designs/system-design-leetcode.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: LeetCode"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Distributed-Systems, Interview-Prep, Security, Real-Time, Sandbox, Scalability, Leaderboard]
 description: "LeetCode serves ~300,000 registered users who practice coding on ~4,000 problems across 20+ languages. The platform also hosts weekly coding competitions drawing 100,000 concurrent contestants — a 30× traffic spike over baseline that lands in the first 60 seconds."
 thumbnail: /images/posts/2026-07-02-system-design-leetcode.svg
 redirect_from:

--- a/_designs/system-design-local-delivery.md
+++ b/_designs/system-design-local-delivery.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Local Delivery"
 category: system-design
 date: 2026-06-29
-tags: [System Design]
+tags: [Distributed-Systems, Geospatial, Real-Time, Event-Driven, Interview-Prep]
 description: "Local Delivery connects customers, restaurants, and couriers in a three-sided marketplace — a customer opens the app, searches for restaurants near their address, builds a cart from a live menu, and checks out."
 thumbnail: /images/posts/2026-06-29-system-design-local-delivery.svg
 redirect_from:

--- a/_designs/system-design-metrics-monitoring.md
+++ b/_designs/system-design-metrics-monitoring.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Metrics Monitoring"
 category: system-design
 date: 2026-07-08
-tags: [System Design]
+tags: [Metrics, Monitoring, Prometheus, Datadog, TSDB]
 description: "A metrics monitoring platform ingests time-series data from hundreds of thousands of services, stores it durably, and answers sub-second dashboard queries while evaluating alert rules against a streaming firehose."
 thumbnail: /images/posts/system-design-metrics-monitoring.svg
 ---

--- a/_designs/system-design-ml-fraud-detection.md
+++ b/_designs/system-design-ml-fraud-detection.md
@@ -5,7 +5,7 @@ category: system-design-ml
 redirect_from:
   - /designs/ml-system-design-fraud-detection/
 date: 2026-07-08
-tags: [System Design]
+tags: [Machine-Learning, Fraud-Detection, Classification, Real-Time, Anomaly-Detection]
 description: "A payment platform processes millions of transactions daily. Every transaction carries a risk: a stolen card used for a high-value purchase, a merchant fabricating orders to collect on chargebacks, a fraud ring testing compromised cards with micro-transactions before draining accounts."
 thumbnail: /images/posts/system-design-ml-fraud-detection.svg
 ---

--- a/_designs/system-design-ml-search-ranking-web-search.md
+++ b/_designs/system-design-ml-search-ranking-web-search.md
@@ -5,7 +5,7 @@ category: system-design-ml
 redirect_from:
   - /designs/ml-system-design-search-ranking-web-search/
 date: 2026-07-08
-tags: [System Design]
+tags: [Machine-Learning, Search-Ranking, Ranking, Retrieval, Web-Search]
 description: "A web-scale search engine receives 40K+ queries per second and must return a ranked list of the most relevant documents from a corpus of over 100 billion pages. Users type a few words and expect the answer in the top three results — if the answer isn't there, they reformulate or leave."
 thumbnail: /images/posts/system-design-ml-search-ranking-web-search.svg
 ---

--- a/_designs/system-design-netflix.md
+++ b/_designs/system-design-netflix.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Netflix"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Interview-Prep, Distributed-Systems, Streaming, Video, CDR, Personalization, Recommendation]
 description: "Netflix streams on-demand video to 325M+ paid subscribers across 190 countries, ingests 500+ hours of new content per minute, and serves ~15% of global internet downstream traffic."
 thumbnail: /images/posts/2026-07-02-system-design-netflix.svg
 redirect_from:

--- a/_designs/system-design-news-feed.md
+++ b/_designs/system-design-news-feed.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: News Feed"
 category: system-design
 date: 2026-07-02
-tags: [System Design, Social Media, Feed]
+tags: [Interview-Prep, Distributed-Systems, Social-Media, Caching, Fan-Out, Re-Design]
 description: "A social media news feed must distribute every post to every follower, rank millions of candidate posts per user by predicted engagement, and serve the result in under 500ms — across 2B+ monthly active users."
 thumbnail: /images/posts/2026-07-02-system-design-news-feed.svg
 redirect_from:

--- a/_designs/system-design-online-chess.md
+++ b/_designs/system-design-online-chess.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Online Chess"
 category: system-design
 date: 2026-07-01
-tags: [System Design]
+tags: [Real-Time, WebSocket, Game]
 description: "Online chess is a real-time two-player game where every half-second of latency feels like an eternity."
 thumbnail: /images/posts/2026-07-01-system-design-online-chess.svg
 mvp_repo: https://github.com/iliazlobin/sd-online-chess-backend-mvp

--- a/_designs/system-design-payment-system.md
+++ b/_designs/system-design-payment-system.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Payment System"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Interview-Prep, Distributed-Systems, Fintech]
 description: "A payment system moves money from a customer's funding source to a merchant's account through payment service providers (PSPs) like Stripe and Adyen. The system authorizes funds, captures them, and records every movement in a double-entry ledger so the books balance to the cent."
 thumbnail: /images/posts/2026-07-02-system-design-payment-system.svg
 redirect_from:

--- a/_designs/system-design-post-search.md
+++ b/_designs/system-design-post-search.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Post Search"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Search, Indexing, Social]
 description: "Post Search lets users find social media posts by keyword, phrase, or semantic meaning across billions of posts, returning ranked results in under 200ms. The system ingests millions of new posts per minute, indexes them in near real-time, and serves search traffic from a global user base."
 thumbnail: /images/posts/2026-07-02-system-design-post-search.svg
 redirect_from:

--- a/_designs/system-design-rate-limiter.md
+++ b/_designs/system-design-rate-limiter.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Rate Limiter"
 category: system-design
 date: 2026-07-01
-tags: [System Design]
+tags: [Distributed-Systems, Caching, Real-Time, Interview-Prep]
 description: "A rate limiter controls how many requests a client can make within a time window. It sits in the request path for every API call, enforcing configurable limits — per user, per IP, or per API key — and rejecting excess traffic with HTTP 429."
 thumbnail: /images/posts/2026-07-01-system-design-rate-limiter.svg
 redirect_from:

--- a/_designs/system-design-stock-trading-platform.md
+++ b/_designs/system-design-stock-trading-platform.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Stock Trading Platform"
 category: system-design
 date: 2026-07-02
-tags: [System Design, Trading, Finance, Real-time]
+tags: [Interview-Prep, Distributed-Systems, Fintech, Real-Time]
 description: "Stock trading platforms connect 23M+ retail investors to US equity markets, routing 15M orders a day through market makers and exchanges. Unlike an exchange — which maintains its own order book and matches buyers against sellers — a brokerage is a custody-and-routing layer."
 thumbnail: /images/posts/system-design-stock-trading-platform.svg
 mvp_repo: https://github.com/iliazlobin/sd-stock-trading-platform-backend-mvp

--- a/_designs/system-design-strava.md
+++ b/_designs/system-design-strava.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Strava"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Interview-Prep, Distributed-Systems, Mobile, Geospatial, Re-Design]
 description: "Strava lets athletes record, share, and compete over GPS-tracked activities at a scale where 10 million runs and rides arrive every day."
 thumbnail: /images/posts/2026-07-02-system-design-strava.svg
 redirect_from:

--- a/_designs/system-design-ticketmaster.md
+++ b/_designs/system-design-ticketmaster.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Ticketmaster"
 category: system-design
 date: 2026-06-30
-tags: [System Design]
+tags: [Interview-Prep, Distributed-Systems, Concurrency, Booking, Re-Design]
 description: "Ticketmaster sells 500M tickets a year across 30 countries as the dominant primary-ticketing marketplace. The hard problem is the flash onsale: 14M people compete for 60,000 seats when Taylor Swift or the Super Bowl goes on sale. Demand outstrips supply 83:1, browse traffic hits 2."
 thumbnail: /images/posts/2026-06-30-system-design-ticketmaster.svg
 redirect_from:

--- a/_designs/system-design-tiktok-reels.md
+++ b/_designs/system-design-tiktok-reels.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: TikTok/Reels"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Interview-Prep, Distributed-Systems, Video, Real-Time, Recommendation, Machine-Learning, Streaming]
 description: "TikTok serves 71 billion video views daily to 1.9 billion monthly users, with 34 million new uploads flowing through a GPU transcoding pipeline every 24 hours."
 thumbnail: /images/posts/2026-07-02-system-design-tiktok-reels.svg
 redirect_from:

--- a/_designs/system-design-tinder.md
+++ b/_designs/system-design-tinder.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Tinder"
 category: system-design
 date: 2026-06-30
-tags: [System Design]
+tags: [Interview-Prep, Geospatial, Distributed-Systems, Real-Time]
 description: "Tinder is a mobile dating app where users create profiles, set discovery preferences, and swipe through a stack of nearby profiles — right to like, left to pass. When two users mutually like each other, a match is formed and they can message."
 thumbnail: /images/posts/2026-06-30-system-design-tinder.svg
 redirect_from:

--- a/_designs/system-design-top-k.md
+++ b/_designs/system-design-top-k.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Top-K"
 category: system-design
 date: 2026-06-30
-tags: [System Design]
+tags: [Real-Time, Write-Heavy, Streaming, Data-Structures]
 description: "A video platform ingests view events at massive scale — 70 billion per day across billions of videos — and must surface the most-viewed videos per time window at sub-50ms read latency."
 thumbnail: /images/posts/2026-06-30-system-design-top-k.svg
 redirect_from:

--- a/_designs/system-design-twitter-x.md
+++ b/_designs/system-design-twitter-x.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Twitter/X"
 category: system-design
 date: 2026-07-02
-tags: [System Design, Social Media, Real-time]
+tags: [Distributed-Systems, Social-Media, Caching, Fan-Out, Real-Time, Timeline, Search]
 description: "Design a real-time social platform supporting 330M MAU that lets users post tweets (text + media), build timelines of tweets from followed users, search across all public tweets in real time, and discover trending topics."
 thumbnail: /images/posts/2026-07-02-system-design-twitter-x.svg
 redirect_from:

--- a/_designs/system-design-uber.md
+++ b/_designs/system-design-uber.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Uber"
 category: system-design
 date: 2026-06-30
-tags: [System Design]
+tags: [Ride-Sharing, Real-Time, Geospatial]
 description: "Uber connects 170M+ monthly active riders with 5M+ drivers across 10,000+ cities in 70+ countries, processing 15M+ daily trips."
 thumbnail: /images/posts/2026-06-30-system-design-uber.svg
 redirect_from:

--- a/_designs/system-design-video-conferencing-zoom.md
+++ b/_designs/system-design-video-conferencing-zoom.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Video Conferencing (Zoom)"
 category: system-design
 date: 2026-07-07
-tags: [System Design]
+tags: [Video-Conferencing, WebRTC, Real-Time, Zoom, Meeting-Systems, SFU]
 description: "Video conferencing connects hundreds of participants in a real-time audio/video session where every frame must travel from a speaker's camera to every listener's screen in under 150ms."
 thumbnail: /images/posts/system-design-video-conferencing-zoom.svg
 ---

--- a/_designs/system-design-web-crawler.md
+++ b/_designs/system-design-web-crawler.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Web Crawler"
 category: system-design
 date: 2026-07-02
-tags: [System Design]
+tags: [Distributed-Systems, Write-Heavy, Interview-Prep]
 description: "A web crawler that ingests ~10 billion web pages and extracts their text content to build an LLM training dataset. The crawl must complete in under 5 days, fetching pages from hundreds of millions of distinct hosts while respecting per-host rate limits and robots.txt."
 thumbnail: /images/posts/2026-07-02-system-design-web-crawler.svg
 redirect_from:

--- a/_designs/system-design-whatsapp.md
+++ b/_designs/system-design-whatsapp.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: WhatsApp"
 category: system-design
 date: 2026-06-30
-tags: [System Design]
+tags: [Distributed-Systems, Real-Time, Event-Driven, Write-Heavy]
 description: "A global messaging platform serving 3B+ users who exchange over 100B messages and 10 PB of media daily."
 thumbnail: /images/posts/2026-06-30-system-design-whatsapp.svg
 redirect_from:

--- a/_designs/system-design-youtube.md
+++ b/_designs/system-design-youtube.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: YouTube"
 category: system-design
 date: 2026-06-30
-tags: [System Design]
+tags: [Streaming, Leaderboard, Real-Time, Video, Approximate-Algorithms, Distributed-Systems, Kafka, Flink]
 description: "YouTube ingests over 70 billion view events per day across more than 4 billion distinct videos, serving over 500 million daily active users who watch over a billion hours of content."
 thumbnail: /images/posts/2026-06-30-system-design-youtube.svg
 redirect_from:

--- a/_designs/video-recommendations.md
+++ b/_designs/video-recommendations.md
@@ -3,7 +3,7 @@ layout: post
 title: "ML System Design: Video Recommendations"
 category: system-design-ml
 date: 2026-07-08
-tags: [System Design]
+tags: [Machine-Learning, Video-Recommendation, Recommendation, Ranking]
 description: "A billion people watch videos every day across a corpus of a billion uploads. After each video finishes, the system serves 5 recommendations — the \"Up Next\" slate."
 thumbnail: /images/posts/video-recommendations.svg
 ---

--- a/_designs/yelp.md
+++ b/_designs/yelp.md
@@ -3,7 +3,7 @@ layout: post
 title: "System Design: Yelp"
 category: system-design
 date: 2026-06-30
-tags: [System Design]
+tags: [Search, Geospatial, Read-Heavy, Real-Time, Advertising, Interview-Prep]
 description: "Yelp is a local business discovery platform connecting ~74M monthly visitors with ~8.4M businesses across categories like restaurants, home services, and retail. Users search by location and keyword, browse ~330M reviews and ~500M photos, and contribute their own ratings and content."
 thumbnail: /images/posts/2026-06-30-yelp.svg
 redirect_from:


### PR DESCRIPTION
The design pages published before the tag fix all showed `tags: [System Design]`. This backfills each page's front-matter `tags:` from its Notion row's `Tags` multi-select (via the new `sync-design-tags.py`), so /designs and /machine-learning tag search now shows real topics. Only the `tags:` line changes per page — no body/diagram changes. All 50 Notion rows already had good tags; this is pure propagation.