### PR TITLE
system-design: fix ETA title (strip version)

### DIFF
--- a/_designs/ml-system-design-eta-arrival-time-prediction.md
+++ b/_designs/ml-system-design-eta-arrival-time-prediction.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "ML System Design: ETA / Arrival Time Prediction (v2026-07-09.1)"
+title: "ML System Design: ETA / Arrival Time Prediction"
 category: system-design-ml
 date: 2026-07-15
 tags: [Machine-Learning, Regression, Forecasting]


### PR DESCRIPTION
Converter now strips hyphenated (v2026-07-09.1) version dates from the title front-matter. Title-only change.