### PR TITLE
Add Agents section to nav (/agents/ tab)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ header_pages:
   - infrastructure.md
   - tech.md
   - research.md
+  - agents.md
   - blog.md
   - index.md
 

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Agents
+permalink: /agents/
+description: "AI agent write-ups by Ilia Zlobin — agentic system designs and deep dives: multi-agent orchestration, tool use, memory, evaluation, and the harnesses that turn LLMs into reliable autonomous workers."
+---
+
+<link rel="stylesheet" href="{{ '/assets/css/portfolio.css' | relative_url }}?v={{ site.time | date: '%s' }}">
+<style>
+  /* Reuses the Portfolio layout; the card title is a link to the write-up, so keep it
+     reading as a heading (not default link-blue) and only tint on hover. */
+  .portfolio-item h3 a { color: inherit; text-decoration: none; }
+  .portfolio-item h3 a:hover { color: var(--accent); }
+</style>
+
+<p class="portfolio-intro">AI agents in practice — designs and deep dives on agentic systems: multi-agent orchestration, tool use, planning and memory, evaluation, and the harnesses that turn LLMs into reliable autonomous workers. Diagrams and code throughout.</p>
+
+{% include design-list.html category="agents" prefix="Agents: " label="Agents" empty_text="No agent write-ups yet — first ones landing soon." %}


### PR DESCRIPTION
New `/agents/` page rendering the `_designs` collection filtered on `category: agents` (same Portfolio-style rail + feed as /research/ and /tech/), added to `header_pages` between Research and Blog. Shows an empty-state line until the first agent write-ups publish.

Publishing side: `notion-to-jekyll.py` gains an `Agents:` title-prefix route → `category: agents` (companion hermes-config change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198w2hcRxhzRkZWoCqPDzKk